### PR TITLE
Faq ver1

### DIFF
--- a/front-react/src/App.js
+++ b/front-react/src/App.js
@@ -11,6 +11,9 @@ import Callback from './pages/login/social/components/Callback';
 import SocialSignup from './pages/login/SocialSignup';
 import Welcome from './pages/login/Welcome';
 import ErpMain from "./erp/ErpMain";
+import FAQList from './faq/FAQList';
+import FAQPut from './faq/FAQPut';
+import FAQPost from './faq/FAQPost';
 
 function App() {
   return (
@@ -27,6 +30,9 @@ function App() {
           <Route path="/social-signup" element={<SocialSignup/>}/>
           <Route path="/Welcome" element={<Welcome/>}/>
           <Route path="/erpMain" element={<ErpMain/>} />
+          <Route path="/faqlist" element={<FAQList/>} />
+          <Route path="/faqput/:qa_id" element={<FAQPut/>} />
+          <Route path="/faqpost" element={<FAQPost/>} />
         </Routes>
         <Footer />
       </BrowserRouter>

--- a/front-react/src/common/Header.jsx
+++ b/front-react/src/common/Header.jsx
@@ -90,6 +90,7 @@ function Header() {
                   <NavDropdown.Item href="#action4">노하우&팁</NavDropdown.Item>
                   <NavDropdown.Item href="#action4">티코 이야기</NavDropdown.Item>
                   <NavDropdown.Item href="#action4">공지사항</NavDropdown.Item>
+                  <NavDropdown.Item href="faqlist">FAQ</NavDropdown.Item>
                   <NavDropdown.Item href="#action5">탐험하기</NavDropdown.Item>
                 </NavDropdown>
               </Nav>

--- a/front-react/src/erp/ErpMain.jsx
+++ b/front-react/src/erp/ErpMain.jsx
@@ -16,6 +16,7 @@ import { FaGear } from "react-icons/fa6";
 import Home from "./Home";
 import AdminRegister from "./AdminRegister";
 import AdminInfo from "./AdminInfo";
+import FAQPut from "../faq/FAQPut";
 
 
 
@@ -37,7 +38,11 @@ function ErpMain() {
       case '2-2':
         setContent(<AdminInfo />);
         break;
-          
+      
+        
+      case '6-4':
+      setContent(<FAQPut />);
+      break;
       // ... 다른 메뉴 항목에 대한 콘텐츠 설정 ...
       default:
         setContent(null); // 기본적으로 null 설정
@@ -93,6 +98,7 @@ function ErpMain() {
                 <Nav.Item eventKey="6-1">결제 관련 문의 관리</Nav.Item>
                 <Nav.Item eventKey="6-2">환불/취소 문의 관리</Nav.Item>
                 <Nav.Item eventKey="6-3">공지사항 관리</Nav.Item>
+                <Nav.Item eventKey="6-4">FAQ 관리</Nav.Item>
               </Nav.Menu>
 
               <Nav.Menu placement="rightStart" eventKey="7" title="콘텐츠 관리팀(MO)" icon={<Icon as={TbPlayCardStarFilled}/>}>

--- a/front-react/src/faq/Ecommerce_FAQ_Chatbot_dataset.json
+++ b/front-react/src/faq/Ecommerce_FAQ_Chatbot_dataset.json
@@ -1,0 +1,326 @@
+{
+  "questions": [
+  {
+  "question": "How can I create an account?",
+  "answer": "To create an account, click on the 'Sign Up' button on the top right corner of our website and follow the instructions to complete the registration process."
+  },
+  {
+  "question": "What payment methods do you accept?",
+  "answer": "We accept major credit cards, debit cards, and PayPal as payment methods for online orders."
+  },
+  {
+  "question": "How can I track my order?",
+  "answer": "You can track your order by logging into your account and navigating to the 'Order History' section. There, you will find the tracking information for your shipment."
+  },
+  {
+  "question": "What is your return policy?",
+  "answer": "Our return policy allows you to return products within 30 days of purchase for a full refund, provided they are in their original condition and packaging. Please refer to our Returns page for detailed instructions."
+  },
+  {
+  "question": "Can I cancel my order?",
+  "answer": "You can cancel your order if it has not been shipped yet. Please contact our customer support team with your order details, and we will assist you with the cancellation process."
+  },
+  {
+  "question": "How long does shipping take?",
+  "answer": "Shipping times vary depending on the destination and the shipping method chosen. Standard shipping usually takes 3-5 business days, while express shipping can take 1-2 business days."
+  },
+  {
+  "question": "Do you offer international shipping?",
+  "answer": "Yes, we offer international shipping to select countries. The availability and shipping costs will be calculated during the checkout process based on your location."
+  },
+  {
+  "question": "What should I do if my package is lost or damaged?",
+  "answer": "If your package is lost or damaged during transit, please contact our customer support team immediately. We will initiate an investigation and take the necessary steps to resolve the issue."
+  },
+  {
+  "question": "Can I change my shipping address after placing an order?",
+  "answer": "If you need to change your shipping address, please contact our customer support team as soon as possible. We will do our best to update the address if the order has not been shipped yet."
+  },
+  {
+  "question": "How can I contact customer support?",
+  "answer": "You can contact our customer support team by phone at [phone number] or by email at [email address]. Our team is available [working hours] to assist you with any inquiries or issues you may have."
+  },
+  {
+  "question": "Do you offer gift wrapping services?",
+  "answer": "Yes, we offer gift wrapping services for an additional fee. During the checkout process, you can select the option to add gift wrapping to your order."
+  },
+  {
+  "question": "What is your price matching policy?",
+  "answer": "We have a price matching policy where we will match the price of an identical product found on a competitor's website. Please contact our customer support team with the details of the product and the competitor's offer."
+  },
+  {
+  "question": "Can I order by phone?",
+  "answer": "Unfortunately, we do not accept orders over the phone. Please place your order through our website for a smooth and secure transaction."
+  },
+  {
+  "question": "Are my personal and payment details secure?",
+  "answer": "Yes, we take the security of your personal and payment details seriously. We use industry-standard encryption and follow strict security protocols to ensure your information is protected."
+  },
+  {
+  "question": "What is your price adjustment policy?",
+  "answer": "If a product you purchased goes on sale within 7 days of your purchase, we offer a one-time price adjustment. Please contact our customer support team with your order details to request the adjustment."
+  },
+  {
+  "question": "Do you have a loyalty program?",
+  "answer": "Yes, we have a loyalty program where you can earn points for every purchase. These points can be redeemed for discounts on future orders. Please visit our website to learn more and join the program."
+  },
+  {
+  "question": "Can I order without creating an account?",
+  "answer": "Yes, you can place an order as a guest without creating an account. However, creating an account offers benefits such as order tracking and easier future purchases."
+  },
+  {
+  "question": "Do you offer bulk or wholesale discounts?",
+  "answer": "Yes, we offer bulk or wholesale discounts for certain products. Please contact our customer support team or visit our Wholesale page for more information and to discuss your specific requirements."
+  },
+  {
+  "question": "Can I change or cancel an item in my order?",
+  "answer": "If you need to change or cancel an item in your order, please contact our customer support team as soon as possible. We will assist you with the necessary steps."
+  },
+  {
+  "question": "How can I leave a product review?",
+  "answer": "To leave a product review, navigate to the product page on our website and click on the 'Write a Review' button. You can share your feedback and rating based on your experience with the product."
+  },
+  {
+  "question": "Can I use multiple promo codes on a single order?",
+  "answer": "Usually, only one promo code can be applied per order. During the checkout process, enter the promo code in the designated field to apply the discount to your order."
+  },
+  {
+  "question": "What should I do if I receive the wrong item?",
+  "answer": "If you receive the wrong item in your order, please contact our customer support team immediately. We will arrange for the correct item to be shipped to you and assist with returning the wrong item."
+  },
+  {
+  "question": "Do you offer expedited shipping?",
+  "answer": "Yes, we offer expedited shipping options for faster delivery. During the checkout process, you can select the desired expedited shipping method."
+  },
+  {
+  "question": "Can I order a product that is out of stock?",
+  "answer": "If a product is currently out of stock, you will usually see an option to sign up for product notifications. This way, you will be alerted when the product becomes available again."
+  },
+  {
+  "question": "What is your email newsletter about?",
+  "answer": "Our email newsletter provides updates on new product releases, exclusive offers, and helpful tips related to our products. You can subscribe to our newsletter on our website."
+  },
+  {
+  "question": "Can I return a product if I changed my mind?",
+  "answer": "Yes, you can return a product if you changed your mind. Please ensure the product is in its original condition and packaging, and refer to our return policy for instructions."
+  },
+  {
+  "question": "Do you offer live chat support?",
+  "answer": "Yes, we offer live chat support on our website during our business hours. Look for the chat icon in the bottom right corner to initiate a chat with our customer support team."
+  },
+  {
+  "question": "Can I order a product as a gift?",
+  "answer": "Yes, you can order a product as a gift and have it shipped directly to the recipient. During the checkout process, you can enter the recipient's shipping address."
+  },
+  {
+  "question": "What should I do if my discount code is not working?",
+  "answer": "If your discount code is not working, please double-check the terms and conditions associated with the code. If the issue persists, contact our customer support team for assistance."
+  },
+  {
+  "question": "Can I return a product if it was a final sale item?",
+  "answer": "Final sale items are usually non-returnable and non-refundable. Please review the product description or contact our customer support team to confirm the return eligibility for specific items."
+  },
+  {
+  "question": "Do you offer installation services for your products?",
+  "answer": "Installation services are available for select products. Please check the product description or contact our customer support team for more information and to request installation services."
+  },
+  {
+  "question": "Can I order a product that is discontinued?",
+  "answer": "Discontinued products are no longer available for purchase. We recommend exploring alternative products on our website."
+  },
+  {
+  "question": "Can I return a product without a receipt?",
+  "answer": "A receipt or proof of purchase is usually required for returns. Please refer to our return policy or contact our customer support team for assistance."
+  },
+  {
+  "question": "Can I order a product for delivery to a different country?",
+  "answer": "Yes, we offer international shipping to select countries. Please review the available shipping destinations during checkout or contact our customer support for assistance."
+  },
+  {
+  "question": "Can I add a gift message to my order?",
+  "answer": "Yes, you can add a gift message during the checkout process. There is usually a section where you can enter your personalized message."
+  },
+  {
+  "question": "Can I request a product demonstration before making a purchase?",
+  "answer": "We do not currently offer product demonstrations before purchase. However, you can find detailed product descriptions, specifications, and customer reviews on our website."
+  },
+  {
+  "question": "Can I order a product that is listed as 'coming soon'?",
+  "answer": "Products listed as 'coming soon' are not available for immediate purchase. Please sign up for notifications to be informed when the product becomes available."
+  },
+  {
+  "question": "Can I request an invoice for my order?",
+  "answer": "Yes, an invoice is usually included with your order. If you require a separate invoice, please contact our customer support team with your order details."
+  },
+  {
+  "question": "Can I order a product that is labeled as 'limited edition'?",
+  "answer": "'Limited edition' products may have restricted availability. We recommend placing an order as soon as possible to secure your item."
+  },
+  {
+  "question": "Can I return a product if I no longer have the original packaging?",
+  "answer": "While returning a product in its original packaging is preferred, you can still initiate a return without it. Contact our customer support team for guidance in such cases."
+  },
+  {
+  "question": "Can I request a product that is currently out of stock to be reserved for me?",
+  "answer": "We do not offer reservations for out-of-stock products. However, you can sign up for product notifications to be alerted when it becomes available again."
+  },
+  {
+  "question": "Can I order a product that is listed as 'pre-order' with other in-stock items?",
+  "answer": "Yes, you can place an order with a mix of pre-order and in-stock items. However, please note that the entire order will be shipped once all items are available."
+  },
+  {
+  "question": "Can I return a product if it was damaged during shipping?",
+  "answer": "If your product was damaged during shipping, please contact our customer support team immediately. We will guide you through the return and replacement process."
+  },
+  {
+  "question": "Can I request a product that is out of stock to be restocked?",
+  "answer": "We strive to restock popular products whenever possible. Please sign up for product notifications to be informed when the item becomes available again."
+  },
+  {
+  "question": "Can I order a product if it is listed as 'backordered'?",
+  "answer": "Products listed as 'backordered' are temporarily out of stock but can still be ordered. Your order will be fulfilled once the product is restocked."
+  },
+  {
+  "question": "Can I return a product if it was purchased during a sale or with a discount?",
+  "answer": "Yes, you can return a product purchased during a sale or with a discount. The refund will be processed based on the amount paid after the discount."
+  },
+  {
+  "question": "Can I request a product repair or replacement if it is damaged?",
+  "answer": "If you receive a damaged product, please contact our customer support team immediately. We will assist you with the necessary steps for repair or replacement."
+  },
+  {
+  "question": "Can I order a product if it is listed as 'out of stock' but available for pre-order?",
+  "answer": "If a product is available for pre-order, you can place an order to secure your item. The product will be shipped once it becomes available."
+  },
+  {
+  "question": "Can I return a product if it was purchased as a gift?",
+  "answer": "Yes, you can return a product purchased as a gift. However, refunds will typically be issued to the original payment method used for the purchase."
+  },
+  {
+  "question": "Can I request a product if it is listed as 'discontinued'?",
+  "answer": "Unfortunately, if a product is listed as 'discontinued,' it is no longer available for purchase. We recommend exploring alternative products on our website."
+  },
+  {
+  "question": "Can I order a product if it is listed as 'sold out'?",
+  "answer": "If a product is listed as 'sold out,' it is currently unavailable for purchase. Please check back later or sign up for notifications when it becomes available again."
+  },
+  {
+  "question": "Can I return a product if it was purchased with a gift card?",
+  "answer": "Yes, you can return a product purchased with a gift card. The refund will be issued in the form of store credit or a new gift card."
+  },
+  {
+  "question": "Can I request a product if it is not currently available in my size?",
+  "answer": "If a product is not available in your size, it may be temporarily out of stock. Please check back later or sign up for size notifications."
+  },
+  {
+  "question": "Can I order a product if it is listed as 'coming soon' but available for pre-order?",
+  "answer": "If a product is listed as 'coming soon' and available for pre-order, you can place an order to secure your item before it becomes available."
+  },
+  {
+  "question": "Can I return a product if it was purchased with a discount code?",
+  "answer": "Yes, you can return a product purchased with a discount code. The refund will be processed based on the amount paid after the discount."
+  },
+  {
+  "question": "Can I request a custom order or personalized product?",
+  "answer": "We do not currently offer custom orders or personalized products. Please explore the available products on our website."
+  },
+  {
+  "question": "Can I order a product if it is listed as 'temporarily unavailable'?",
+  "answer": "If a product is listed as 'temporarily unavailable,' it is out of stock but may be restocked in the future. Please check back later or sign up for notifications."
+  },
+  {
+  "question": "Can I return a product if it was damaged due to improper use?",
+  "answer": "Our return policy generally covers products that are defective or damaged upon arrival. Damage due to improper use may not be eligible for a return. Please contact our customer support team for assistance."
+  },
+  {
+  "question": "Can I request a product if it is listed as 'coming soon' but not available for pre-order?",
+  "answer": "If a product is listed as 'coming soon' but not available for pre-order, you will need to wait until it is officially released and becomes available for purchase."
+  },
+  {
+  "question": "Can I order a product if it is listed as 'on hold'?",
+  "answer": "If a product is listed as 'on hold,' it is temporarily unavailable for purchase. Please check back later or sign up for notifications when it becomes available."
+  },
+  {
+  "question": "Can I return a product if I no longer have the original receipt?",
+  "answer": "While a receipt is preferred for returns, we may be able to assist you without it. Please contact our customer support team for further guidance."
+  },
+  {
+  "question": "Can I request a product that is listed as 'limited edition' to be restocked?",
+  "answer": "Once a limited edition product is sold out, it may not be restocked. Limited edition items are available for a limited time only, so we recommend purchasing them while they are available."
+  },
+  {
+  "question": "Can I order a product if it is listed as 'discontinued' but still visible on the website?",
+  "answer": "If a product is listed as 'discontinued' but still visible on the website, it may be an error. Please contact our customer support team for clarification."
+  },
+  {
+  "question": "Can I return a product if it was a clearance or final sale item?",
+  "answer": "Clearance or final sale items are typically non-returnable and non-refundable. Please review the product description or contact our customer support team for more information."
+  },
+  {
+  "question": "Can I request a product if it is not listed on your website?",
+  "answer": "If a product is not listed on our website, it may not be available for purchase. We recommend exploring the available products or contacting our customer support team for further assistance."
+  },
+  {
+  "question": "Can I order a product if it is listed as 'out of stock' but available for backorder?",
+  "answer": "If a product is listed as 'out of stock' but available for backorder, you can place an order to secure your item. The product will be shipped once it becomes available."
+  },
+  {
+  "question": "Can I return a product if it was purchased as part of a bundle or set?",
+  "answer": "If a product was purchased as part of a bundle or set, the return policy may vary. Please refer to the specific terms and conditions or contact our customer support team for further guidance."
+  },
+  {
+  "question": "Can I request a product that is listed as 'out of stock' to be restocked?",
+  "answer": "We aim to restock popular products whenever possible. Please sign up for product notifications to be alerted when the item becomes available again."
+  },
+  {
+  "question": "Can I order a product if it is listed as 'coming soon' and available for pre-order?",
+  "answer": "If a product is listed as 'coming soon' and available for pre-order, you can place an order to secure your item before it becomes available."
+  },
+  {
+  "question": "Can I return a product if it was damaged due to mishandling during shipping?",
+  "answer": "If your product was damaged due to mishandling during shipping, please contact our customer support team immediately. We will assist you with the necessary steps for return and replacement."
+  },
+  {
+  "question": "Can I request a product that is listed as 'out of stock' to be reserved for me?",
+  "answer": "We do not offer reservations for out-of-stock products. However, you can sign up for product notifications to be alerted when the item becomes available again."
+  },
+  {
+  "question": "Can I order a product if it is listed as 'pre-order' but available for backorder?",
+  "answer": "If a product is listed as 'pre-order' and available for backorder, you can place an order to secure your item. The product will be shipped once it becomes available."
+  },
+  {
+  "question": "Can I return a product if it was purchased with store credit?",
+  "answer": "Yes, you can return a product purchased with store credit. The refund will be issued in the form of store credit, which you can use for future purchases."
+  },
+  {
+  "question": "Can I request a product that is currently out of stock to be restocked?",
+  "answer": "We strive to restock popular products whenever possible. Please sign up for product notifications to be informed when the item becomes available again."
+  },
+  {
+  "question": "Can I order a product if it is listed as 'sold out' but available for pre-order?",
+  "answer": "If a product is listed as 'sold out' but available for pre-order, you can place an order to secure your item. The product will be shipped once it becomes available."
+  },
+  {
+  "question": "Can I return a product if it was purchased with a promotional gift card?",
+  "answer": "Yes, you can return a product purchased with a promotional gift card. The refund will be issued in the form of store credit or a new gift card."
+  },
+  {
+  "question": "Can I request a product if it is not currently available in my preferred color?",
+  "answer": "If a product is not available in your preferred color, it may be temporarily out of stock. Please check back later or sign up for color notifications."
+  },
+  {
+  "question": "Can I order a product if it is listed as 'coming soon' and not available for pre-order?",
+  "answer": "If a product is listed as 'coming soon' but not available for pre-order, you will need to wait until it is officially released and becomes available for purchase."
+  },
+  {
+  "question": "Can I return a product if it was purchased during a promotional event?",
+  "answer": "Yes, you can return a product purchased during a promotional event. The refund will be processed based on the amount paid after any applicable discounts."
+  }
+  ]
+  }
+  
+  
+  
+  
+  
+  

--- a/front-react/src/faq/FAQList.js
+++ b/front-react/src/faq/FAQList.js
@@ -61,6 +61,13 @@ function FAQList() {
                     </Accordion.Item>
                 </Accordion>
             ))}
+
+            <div className="text-center my-4">
+                <Button variant="success" size="lg" onClick={() => navigate('/faqpost')}>
+                    ➕ FAQ 등록하기
+                </Button>
+            </div>
+
         </div>
     );
 }

--- a/front-react/src/faq/FAQList.js
+++ b/front-react/src/faq/FAQList.js
@@ -64,22 +64,6 @@ function FAQList() {
             ))}
           </Accordion>
 
-          <div className="text-center my-5">
-            <Button
-              variant="success"
-              size="lg"
-              onClick={() => navigate('/faqpost')}
-              style={{
-                padding: '12px 30px',
-                fontSize: '18px',
-                fontWeight: 'bold',
-                borderRadius: '8px',
-                boxShadow: '0 4px 10px rgba(0, 128, 0, 0.2)',
-              }}
-            >
-                FAQ 등록하기
-            </Button>
-          </div>
         </div>
     );
 }

--- a/front-react/src/faq/FAQList.js
+++ b/front-react/src/faq/FAQList.js
@@ -24,50 +24,62 @@ function FAQList() {
 
         fetchFaqData();
     }, []);
-
-    const deleteCheck = async (id) => {
-        if (window.confirm(`정말 [${id}번] 항목을 삭제하시겠습니까?`)) {
-            try {
-                const response = await fetch(`http://localhost:8081/api/faqDelete/${id}`, { method: 'DELETE' });
-                if (!response.ok) {
-                    throw new Error('FAQ 삭제에 실패했습니다.');
-                }
-                alert('삭제되었습니다.');
-                // 삭제 성공 시 재렌더링을 위한 상태 업데이트
-                setFaqData((prevData) => prevData.filter((dto) => dto.qa_id !== id));
-            } catch (error) {
-                console.error('FAQ 삭제 중 오류 발생:', error);
-                alert('FAQ 삭제 중 오류가 발생했습니다.');
-            }
-        }
-    };
-
     return (
-        <div className="container mt-4">
-            {faqData.map((dto) => (
-                <Accordion key={dto.qa_id}>
-                    <Accordion.Item eventKey={dto.qa_id}>
-                        <Accordion.Header>
-                            {dto.qa_id}. {dto.question}
-                        </Accordion.Header>
-                        <Accordion.Body>
-                            {dto.answer}
-                            <div>
-                                <p> - 관리자 메뉴 - </p>
-                                <Button variant="primary" size="sm" onClick={() => navigate(`/FAQPut/${dto.qa_id}`)}>수정</Button>
-                                <Button variant="secondary" size="sm" onClick={() => deleteCheck(dto.qa_id)}>삭제</Button>
-                            </div>
-                        </Accordion.Body>
-                    </Accordion.Item>
-                </Accordion>
+        <div className="container mt-5">
+          <h2 className="text-center mb-5 fw-bold">자주 묻는 질문 (FAQ)</h2>
+
+          <Accordion alwaysOpen  style={{ marginTop: '20px' }}>
+            {faqData.map((dto,index) => (
+              <Accordion.Item
+              key={dto.qa_id}
+              eventKey={dto.qa_id}
+              style={{
+                marginBottom: '15px',
+                border: '1px solid #ddd',
+                borderRadius: '10px',
+                overflow: 'hidden', // 내부 둥글게 잘리도록 설정
+                boxShadow: '0 2px 8px rgba(0, 0, 0, 0.05)',
+              }}
+            >
+              <Accordion.Header
+                style={{
+                  fontWeight: 'bold',
+                  backgroundColor: '#fff',
+                }}
+              >
+                {index+1}. {dto.question}
+              </Accordion.Header>
+            
+              <Accordion.Body
+                style={{
+                  fontWeight: 'bold',
+                  fontSize: '16px',
+                  backgroundColor: '#f9f9f9',
+                  padding: '20px',
+                }}
+              >
+                {dto.answer}
+              </Accordion.Body>
+            </Accordion.Item>
             ))}
+          </Accordion>
 
-            <div className="text-center my-4">
-                <Button variant="success" size="lg" onClick={() => navigate('/faqpost')}>
-                    ➕ FAQ 등록하기
-                </Button>
-            </div>
-
+          <div className="text-center my-5">
+            <Button
+              variant="success"
+              size="lg"
+              onClick={() => navigate('/faqpost')}
+              style={{
+                padding: '12px 30px',
+                fontSize: '18px',
+                fontWeight: 'bold',
+                borderRadius: '8px',
+                boxShadow: '0 4px 10px rgba(0, 128, 0, 0.2)',
+              }}
+            >
+                FAQ 등록하기
+            </Button>
+          </div>
         </div>
     );
 }

--- a/front-react/src/faq/FAQList.js
+++ b/front-react/src/faq/FAQList.js
@@ -1,0 +1,68 @@
+import React, { useState, useEffect } from 'react';
+import { Accordion, Button } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
+
+function FAQList() {
+    const [faqData, setFaqData] = useState([]);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        // FAQ 데이터를 가져오는 함수
+        const fetchFaqData = async () => {
+            try {
+                const response = await fetch('http://localhost:8081/api/faqGet', { method: 'GET' });
+                if (!response.ok) {
+                    throw new Error('FAQ 데이터를 불러오는 데 실패했습니다.');
+                }
+                const data = await response.json();
+                setFaqData(data);
+            } catch (error) {
+                console.error('FAQ 데이터를 불러오는 중 오류 발생:', error);
+                alert('FAQ 데이터를 불러오는 중 오류가 발생했습니다.');
+            }
+        };
+
+        fetchFaqData();
+    }, []);
+
+    const deleteCheck = async (id) => {
+        if (window.confirm(`정말 [${id}번] 항목을 삭제하시겠습니까?`)) {
+            try {
+                const response = await fetch(`http://localhost:8081/api/faqDelete/${id}`, { method: 'DELETE' });
+                if (!response.ok) {
+                    throw new Error('FAQ 삭제에 실패했습니다.');
+                }
+                alert('삭제되었습니다.');
+                // 삭제 성공 시 재렌더링을 위한 상태 업데이트
+                setFaqData((prevData) => prevData.filter((dto) => dto.qa_id !== id));
+            } catch (error) {
+                console.error('FAQ 삭제 중 오류 발생:', error);
+                alert('FAQ 삭제 중 오류가 발생했습니다.');
+            }
+        }
+    };
+
+    return (
+        <div className="container mt-4">
+            {faqData.map((dto) => (
+                <Accordion key={dto.qa_id}>
+                    <Accordion.Item eventKey={dto.qa_id}>
+                        <Accordion.Header>
+                            {dto.qa_id}. {dto.question}
+                        </Accordion.Header>
+                        <Accordion.Body>
+                            {dto.answer}
+                            <div>
+                                <p> - 관리자 메뉴 - </p>
+                                <Button variant="primary" size="sm" onClick={() => navigate(`/FAQPut/${dto.qa_id}`)}>수정</Button>
+                                <Button variant="secondary" size="sm" onClick={() => deleteCheck(dto.qa_id)}>삭제</Button>
+                            </div>
+                        </Accordion.Body>
+                    </Accordion.Item>
+                </Accordion>
+            ))}
+        </div>
+    );
+}
+
+export default FAQList;

--- a/front-react/src/faq/FAQPost.js
+++ b/front-react/src/faq/FAQPost.js
@@ -36,22 +36,46 @@ function FAQPost() {
   };
 
   return (
-    <div className="container mt-4">
-      <Form onSubmit={handleSubmit}>
-        <Form.Group className="mb-3">
-          <Form.Label>질문</Form.Label>
-          <Form.Control type="text" value={question} onChange={(e) => setQuestion(e.target.value)} required  />
-        </Form.Group>
+    <div className="container mt-5 mb-5">
+      <div className="row justify-content-center">
+        <div className="col-lg-8">
+          <div className="card shadow-sm rounded p-4">
+            <h2 className="text-center fw-bold mb-4">FAQ 등록</h2>
+            <p className="text-muted text-center mb-4">자주 묻는 질문과 답변을 입력해주세요.</p>
 
-        <Form.Group className="mb-3">
-          <Form.Label>답변</Form.Label>
-          <Form.Control as="textarea" rows={3} value={answer} onChange={(e) => setAnswer(e.target.value)} required />
-        </Form.Group>
+            <Form onSubmit={handleSubmit}>
+              <Form.Group className="mb-3">
+                <Form.Label className="fw-semibold">질문</Form.Label>
+                <Form.Control 
+                  type="text" 
+                  value={question} 
+                  onChange={(e) => setQuestion(e.target.value)} 
+                  required 
+                  placeholder="예: 회원가입은 어떻게 하나요?" 
+                />
+              </Form.Group>
 
-        <Button variant="primary" type="submit">
-          등록
-        </Button>
-      </Form>
+              <Form.Group className="mb-4">
+                <Form.Label className="fw-semibold">답변</Form.Label>
+                <Form.Control 
+                  as="textarea" 
+                  rows={4} 
+                  value={answer} 
+                  onChange={(e) => setAnswer(e.target.value)} 
+                  required 
+                  placeholder="예: 상단 메뉴에서 회원가입 버튼을 클릭하신 후, 정보를 입력해 주세요." 
+                />
+              </Form.Group>
+
+              <div className="text-center">
+                <Button variant="success" type="submit" size="lg">
+                  등록하기
+                </Button>
+              </div>
+            </Form>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/front-react/src/faq/FAQPost.js
+++ b/front-react/src/faq/FAQPost.js
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { Form, Button } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
+
+
+function FAQPost() {
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
+
+  const navigate = useNavigate();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    fetch('http://localhost:8081/api/faqPost', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ question, answer }),
+    })
+      .then((response) => {
+        if (response.ok) {
+          alert('FAQ가 성공적으로 등록되었습니다.');
+          setQuestion(''); // 등록 후 입력필드 초기화
+          setAnswer('');
+          navigate('/FAQList');
+        } else {
+          alert('FAQ 등록에 실패했습니다.');
+        }
+      })
+      .catch((error) => {
+        console.error('오류 발생:', error);
+        alert('오류가 발생했습니다.');
+      });
+  };
+
+  return (
+    <div className="container mt-4">
+      <Form onSubmit={handleSubmit}>
+        <Form.Group className="mb-3">
+          <Form.Label>질문</Form.Label>
+          <Form.Control type="text" value={question} onChange={(e) => setQuestion(e.target.value)} required  />
+        </Form.Group>
+
+        <Form.Group className="mb-3">
+          <Form.Label>답변</Form.Label>
+          <Form.Control as="textarea" rows={3} value={answer} onChange={(e) => setAnswer(e.target.value)} required />
+        </Form.Group>
+
+        <Button variant="primary" type="submit">
+          등록
+        </Button>
+      </Form>
+    </div>
+  );
+}
+
+export default FAQPost;

--- a/front-react/src/faq/FAQPut.js
+++ b/front-react/src/faq/FAQPut.js
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { Form, Button } from 'react-bootstrap';
+import { useNavigate, useParams } from 'react-router-dom';
+
+
+function FAQPut() {
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
+  const propsParam = useParams();
+  const qa_id = propsParam.qa_id;
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // 컴포넌트 마운트 시 FAQ 데이터 가져오기 (fetch 사용)
+    fetch('http://localhost:8081/api/faqGetbyId/'+qa_id, { 
+      method: 'GET',
+    })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('FAQ 데이터를 불러오는 데 실패했습니다.');
+            }
+            return response.json();
+        })
+        .then(data => {
+            setQuestion(data.question);
+            setAnswer(data.answer);
+        })
+        .catch(error => {
+            console.error('FAQ 데이터를 불러오는 중 오류 발생:', error);
+            alert('FAQ 데이터를 불러오는 중 오류가 발생했습니다.');
+        });
+  }, []);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    fetch(`http://localhost:8081/api/faqPut/${qa_id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ question, answer }),
+    })
+      .then((response) => {
+        if (response.ok) {
+          alert('FAQ가 성공적으로 수정되었습니다.');
+          setQuestion(''); // 등록 후 입력필드 초기화
+          setAnswer('');
+          navigate('/FAQList');
+        } else {
+          alert('FAQ 수정에 실패했습니다.');
+        }
+      })
+      .catch((error) => {
+        console.error('오류 발생:', error);
+        alert('오류가 발생했습니다.');
+      });
+  };
+
+  return (
+    <div className="container mt-4">
+      <Form onSubmit={handleSubmit}>
+        <Form.Group className="mb-3">
+          <Form.Label>질문</Form.Label>
+          <Form.Control type="text" value={question} onChange={(e) => setQuestion(e.target.value)} required />
+        </Form.Group>
+
+        <Form.Group className="mb-3">
+          <Form.Label>답변</Form.Label>
+          <Form.Control as="textarea" rows={3} value={answer} onChange={(e) => setAnswer(e.target.value)} required />
+        </Form.Group>
+
+        <Button variant="primary" type="submit">
+          수정하기
+        </Button>
+      </Form>
+    </div>
+  );
+}
+
+export default FAQPut;

--- a/front-react/src/faq/FAQPut.js
+++ b/front-react/src/faq/FAQPut.js
@@ -1,82 +1,173 @@
-import React, { useEffect, useState } from 'react';
-import { Form, Button } from 'react-bootstrap';
-import { useNavigate, useParams } from 'react-router-dom';
+import React, { useState, useEffect, useRef } from 'react';
+import { Button, Form, Row, Col, Card } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
 
-
-function FAQPut() {
-  const [question, setQuestion] = useState('');
-  const [answer, setAnswer] = useState('');
-  const propsParam = useParams();
-  const qa_id = propsParam.qa_id;
-
+function FAQList() {
+  const [faqData, setFaqData] = useState([]); // JSON 객체를 담을 배열
   const navigate = useNavigate();
+ 
+  const modCheck = useRef(0); // 변경사항 확인
 
   useEffect(() => {
-    // 컴포넌트 마운트 시 FAQ 데이터 가져오기 (fetch 사용)
-    fetch('http://localhost:8081/api/faqGetbyId/'+qa_id, { 
-      method: 'GET',
-    })
-        .then(response => {
-            if (!response.ok) {
-                throw new Error('FAQ 데이터를 불러오는 데 실패했습니다.');
-            }
-            return response.json();
-        })
-        .then(data => {
-            setQuestion(data.question);
-            setAnswer(data.answer);
-        })
-        .catch(error => {
-            console.error('FAQ 데이터를 불러오는 중 오류 발생:', error);
-            alert('FAQ 데이터를 불러오는 중 오류가 발생했습니다.');
-        });
+    const fetchFaqData = async () => {
+      try {
+        const response = await fetch('http://localhost:8081/api/faqGet');
+        if (!response.ok) throw new Error('FAQ 데이터를 불러오는 데 실패했습니다.');
+        const data = await response.json();
+        setFaqData(data);
+      } catch (error) {
+        console.error('FAQ 데이터를 불러오는 중 오류 발생:', error);
+        alert('FAQ 데이터를 불러오는 중 오류가 발생했습니다.');
+      }
+    };
+    fetchFaqData();
+    modCheck.current = 0;
   }, []);
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
-
-    fetch(`http://localhost:8081/api/faqPut/${qa_id}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ question, answer }),
-    })
-      .then((response) => {
-        if (response.ok) {
-          alert('FAQ가 성공적으로 수정되었습니다.');
-          setQuestion(''); // 등록 후 입력필드 초기화
-          setAnswer('');
-          navigate('/FAQList');
-        } else {
-          alert('FAQ 수정에 실패했습니다.');
-        }
-      })
-      .catch((error) => {
-        console.error('오류 발생:', error);
-        alert('오류가 발생했습니다.');
-      });
+  // FAQ 수정용 핸들러
+  const handleChange = (index, field, value) => {
+    const updated = [...faqData]; // spread 연산자
+    updated[index][field] = value; // 해당 객체의 key값을 변경
+    setFaqData(updated);
+    modCheck.current = 1;
   };
 
+  // 삭제
+  const deleteCheck = async (id) => {
+    if (window.confirm(`정말 [${id}번] 항목을 삭제하시겠습니까?`)) {
+      try {
+        const response = await fetch(`http://localhost:8081/api/faqDelete/${id}`, {
+          method: 'DELETE',
+        });
+        if (!response.ok) throw new Error('FAQ 삭제에 실패했습니다.');
+        alert('삭제되었습니다.');
+        setFaqData((prev) => prev.filter((dto) => dto.qa_id !== id));
+      } catch (error) {
+        console.error('FAQ 삭제 중 오류 발생:', error);
+        alert('FAQ 삭제 중 오류가 발생했습니다.');
+      }
+    }
+  };
+
+  // 개별수정
+  const handleUpdate = async (qa_id, question, answer, index) => {
+    
+    if (!question.trim() || !answer.trim()) { // 공백을 지우고 유효검사
+        alert('질문과 답변은 모두 입력해야 합니다.');
+        return;
+    }
+    
+    const confirmed = window.confirm(`${qa_id}번 FAQ를 수정하시겠습니까?`);
+    if (!confirmed) return;
+    
+    try {
+      const response = await fetch(`http://localhost:8081/api/faqPut/${qa_id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question, answer }),
+      });
+      
+      // 상태만 갱신해서 리렌더링
+      setFaqData((prev) =>
+        prev.map((item) =>
+          item.qa_id === qa_id
+            ? { ...item, question, answer }
+            : item
+        )
+      );
+
+      if (!response.ok) throw new Error('FAQ 수정 실패');
+      alert(`FAQ ${qa_id}번 항목이 성공적으로 수정되었습니다.`);
+      
+  
+    } catch (error) {
+      console.error('FAQ 수정 중 오류:', error);
+      alert(`FAQ ${qa_id} 수정 중 오류가 발생했습니다.`);
+    }
+  };
+
+  // 등록화면으로 넘어가기
+  const postChek = ()=>{
+    if (modCheck.current === 1) {
+        if(window.confirm("변경사항이 있습니다. 등록하기 화면으로 넘어가시겠습니까?.")){
+            navigate('/faqpost')
+        } else return false
+    } else navigate('/faqpost')
+  }
   return (
-    <div className="container mt-4">
-      <Form onSubmit={handleSubmit}>
-        <Form.Group className="mb-3">
-          <Form.Label>질문</Form.Label>
-          <Form.Control type="text" value={question} onChange={(e) => setQuestion(e.target.value)} required />
-        </Form.Group>
+    <div className="container mt-5 mb-5">
+  <h2 className="text-center mb-3">자주 묻는 질문 (FAQ)</h2>
+  <p className="text-muted text-center mb-4">수정 / 삭제</p>
 
-        <Form.Group className="mb-3">
-          <Form.Label>답변</Form.Label>
-          <Form.Control as="textarea" rows={3} value={answer} onChange={(e) => setAnswer(e.target.value)} required />
-        </Form.Group>
+  {/* overflowY: auto는 내부 내용이 넘치면 자동으로 세로 스크롤이 생기게 함 */}
+  <div style={{ maxHeight: '650px', overflowY: 'auto', paddingRight: '8px' }}> 
+    {faqData.map((dto, index) => (
+      <Card key={dto.qa_id} className="mb-4 shadow-sm">
+        <Card.Body>
+          <Row className="align-items-center mb-3">
+            <Col>
+              <b>{index + 1}.</b>
+              <Form.Control
+                type="text"
+                value={dto.question}
+                onChange={(e) => handleChange(index, 'question', e.target.value)}
+                placeholder="질문을 입력하세요"
+                className="fw-bold"
+              />
+            </Col>
+            <Col xs="auto">
+              <Button
+                variant="warning"
+                size="sm"
+                onClick={() =>
+                  handleUpdate(dto.qa_id, dto.question, dto.answer, index)
+                }
+              >
+                수정
+              </Button>
+            </Col>
+            <Col xs="auto">
+              <Button
+                variant="outline-danger"
+                size="sm"
+                onClick={() => deleteCheck(dto.qa_id)}
+                className="me-1"
+              >
+                ❌
+              </Button>
+            </Col>
+          </Row>
+          <Form.Control
+            as="textarea"
+            rows={3}
+            value={dto.answer}
+            onChange={(e) => handleChange(index, 'answer', e.target.value)}
+            placeholder="답변을 입력하세요"
+            style={{ backgroundColor: '#f9f9f9' }}
+          />
+        </Card.Body>
+      </Card>
+    ))}
+  </div>
 
-        <Button variant="primary" type="submit">
-          수정하기
-        </Button>
-      </Form>
-    </div>
+  <div className="d-flex justify-content-center mt-4">
+    <Button
+      variant="primary"
+      size="lg"
+      onClick={() => postChek()}
+      style={{
+        padding: '12px 30px',
+        fontSize: '18px',
+        fontWeight: 'bold',
+        borderRadius: '8px',
+        boxShadow: '0 4px 10px rgba(0, 123, 255, 0.2)',
+      }}
+    >
+      FAQ 새로 등록하기
+    </Button>
+  </div>
+</div>
   );
 }
 
-export default FAQPut;
+export default FAQList;

--- a/front-react/src/faq/faqListPush.py
+++ b/front-react/src/faq/faqListPush.py
@@ -1,0 +1,54 @@
+import json
+import mysql.connector  # pip install mysql-connector-python
+
+def insert_qa_into_mariadb_from_file(json_file_path, db_config, limit=20):
+    """JSON 파일에서 질문-답변 묶음을 최대 limit개까지 읽어 MariaDB 데이터베이스에 삽입합니다."""
+    try:
+        conn = mysql.connector.connect(**db_config)
+        cursor = conn.cursor()
+
+        count = 0
+        with open(json_file_path, "r", encoding="utf-8") as file:
+            data = json.load(file)
+            for item in data["questions"]:
+                if count >= limit:
+                    break
+
+                question = item["question"]
+                answer = item["answer"]
+
+                # ON DUPLICATE KEY UPDATE 는 question이 UNIQUE여야 동작
+                cursor.execute(
+                    "INSERT INTO faq_tb (question, answer) VALUES (%s, %s) "
+                    "ON DUPLICATE KEY UPDATE answer = %s",
+                    (question, answer, answer)
+                )
+                count += 1
+
+        conn.commit()
+        print(f"{count}개의 질문-답변이 MariaDB에 성공적으로 삽입되었습니다.")
+
+    except mysql.connector.Error as e:
+        print(f"오류 발생: {e}")
+    except FileNotFoundError:
+        print(f"오류: 파일을 찾을 수 없습니다: {json_file_path}")
+    except json.JSONDecodeError:
+        print(f"오류: 잘못된 JSON 형식입니다: {json_file_path}")
+    finally:
+        if conn and conn.is_connected():
+            cursor.close()
+            conn.close()
+
+# MariaDB 연결 설정, 여기 수정할 것
+db_config = {
+    "host": "호스트번호",
+    "user": "유저",
+    "password": "비밀번호",
+    "database": "db명",
+}
+
+# JSON 파일 경로
+json_file_path = "./src/faq/Ecommerce_FAQ_Chatbot_dataset.json"
+
+# 함수 호출
+insert_qa_into_mariadb_from_file(json_file_path, db_config, limit=20)

--- a/src/main/java/com/boot/tico/faq/controller/FAQContoroller.java
+++ b/src/main/java/com/boot/tico/faq/controller/FAQContoroller.java
@@ -1,0 +1,64 @@
+package com.boot.tico.faq.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.boot.tico.faq.dto.FAQDTO;
+import com.boot.tico.faq.service.FAQServiceImpl;
+
+@RestController //Controller + ResponseBody (Java 객체를 JSON이나 XML과 같은 형식으로 변환하여 응답 본문에 작성)
+@RequestMapping("/api")
+@CrossOrigin(origins = "http://localhost:3000")
+public class FAQContoroller {
+	
+	@Autowired
+    private FAQServiceImpl faqService;
+	
+	 @PostMapping("/faqPost") // Post 요청이 /faqPost 경로로 들어올 때 실행
+	    public ResponseEntity<?> postFAQ(@RequestBody FAQDTO dto) {
+		 // @RequestBody : HTTP 요청의 본문(request body)에 담긴 데이터를 Java 객체로 변환하는 데 사용
+		 	System.out.println("<<< board >>>");
+		 	return new ResponseEntity<>(faqService.save(dto), HttpStatus.OK);
+		 								// 응답 본문 (body) , 응답 상태
+	    }
+	 
+	 @GetMapping("/faqGet") 
+	    public ResponseEntity<?> getFAQ() {
+		 	System.out.println("<<< board >>>");
+		 	return new ResponseEntity<>(faqService.findAll(), HttpStatus.CREATED);
+		 
+	    }
+	 
+	 @DeleteMapping("/faqDelete/{faq_id}") 
+	    public ResponseEntity<?> deleteFAQ(@PathVariable int faq_id) {
+		 	System.out.println("<<< board Delete >>>");
+		 	return new ResponseEntity<>(faqService.delete(faq_id), HttpStatus.OK);
+		 								
+	    }
+	 
+	 @GetMapping("/faqGetbyId/{faq_id}") 
+	    public ResponseEntity<?> getFAQ(@PathVariable int faq_id) {
+		 	System.out.println("<<< board >>>");
+		 	return new ResponseEntity<>(faqService.findById(faq_id), HttpStatus.CREATED);
+		 
+	    }
+	 
+	 @PutMapping("/faqPut/{faq_id}") 
+	    public ResponseEntity<?> putFAQ(@PathVariable int faq_id, @RequestBody FAQDTO dto) {	 
+		 	System.out.println("<<< board >>>");
+		 	return new ResponseEntity<>(faqService.put(faq_id, dto), HttpStatus.OK);
+		 								
+	    }
+	 
+	 
+}

--- a/src/main/java/com/boot/tico/faq/dao/FAQRepository.java
+++ b/src/main/java/com/boot/tico/faq/dao/FAQRepository.java
@@ -1,0 +1,16 @@
+package com.boot.tico.faq.dao;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.boot.tico.faq.dto.FAQDTO;
+
+@Repository
+public interface FAQRepository extends JpaRepository<FAQDTO, Integer>{
+									// JpaRepository<FAQDto, Integer>는 제네릭 인터페이스로, 두 개의 타입 매개변수를 받습니다.
+									// FAQDto: 데이터베이스 테이블과 매핑되는 엔티티 클래스
+									// Integer: FAQDto 엔티티의 기본 키(Primary Key)의 데이터 타입
+	 Optional<FAQDTO> findByQuestion(String question); // By 뒤 컬럼명에 맞게 자동 쿼리 생성됨, SELECT * FROM faq_tb WHERE question = ?;
+};

--- a/src/main/java/com/boot/tico/faq/dto/FAQDTO.java
+++ b/src/main/java/com/boot/tico/faq/dto/FAQDTO.java
@@ -1,0 +1,31 @@
+package com.boot.tico.faq.dto;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+
+@Data					// @Getter + @Setter
+@AllArgsConstructor		// 매개변수 생성자
+@NoArgsConstructor		// 디폴트 생성자
+@ToString
+@Builder				// 매개변수 생성자에 순서없이 값을 입력해서 세팅해도 마지막에 build()를 통해 빌더를 작동, 같은 타입의 다른 변수의 값을 서로 순서 바꿔넣어도 인식한다는 말인듯?
+@Entity   				// ORM(table의 컬럼과 object의 멤버변수를 매핑)
+@Table(name = "faq_tb")
+public class FAQDTO {
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int qa_id;
+    private String question;
+	private String answer;
+}

--- a/src/main/java/com/boot/tico/faq/service/FAQServiceImpl.java
+++ b/src/main/java/com/boot/tico/faq/service/FAQServiceImpl.java
@@ -1,0 +1,69 @@
+package com.boot.tico.faq.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.boot.tico.faq.dao.FAQRepository;
+import com.boot.tico.faq.dto.FAQDTO;
+
+@Service
+public class FAQServiceImpl {
+	
+	@Autowired
+	private FAQRepository repo;
+	
+	// 등록
+	@Transactional  // 작업의 단위, 메서드 정상 종료시 트랜젝션이 DB로 커밋, 예외 발생시 롤백
+	public FAQDTO save(FAQDTO dto) {
+		Optional<FAQDTO> existing = repo.findByQuestion(dto.getQuestion()); //SELECT * FROM faq_tb WHERE question = dto.getQuestion;
+		// optional은 null일 수도 있는 값을 감싸는 Wrapper, isPresent()로 값 존재 여부 확인, get()으로 내부 값 꺼냄
+	    if (existing.isPresent()) { // 동일한 값이 조회된다면? (null이 아니면 true를 반환)
+	        // 이미 존재하면 answer만 업데이트
+	        FAQDTO existingFaq = existing.get(); //  DB에서 가져온 기존 FAQ 엔티티 객체
+	        existingFaq.setAnswer(dto.getAnswer()); //FAQDTO 클래스에 있는 Setter 메서드
+	        return repo.save(existingFaq); // 답변만 바꿔서 저장
+	    } else {
+	        // 없으면 새로 저장
+	        return repo.save(dto);
+	    }
+	}
+	// 조회
+	@Transactional 
+	public List<FAQDTO> findAll() {
+		return repo.findAll();
+		
+	}
+	// 삭제
+	@Transactional  // 작업의 단위, 메서드 정상 종료시 트랜젝션이 DB로 커밋, 예외 발생시 롤백
+	public String delete(int faq_id) {
+		System.out.println(faq_id+"아이디");
+		repo.deleteById(faq_id);
+		return "ok";
+
+	}
+	// 1건 조회
+	@Transactional  // 작업의 단위, 메서드 정상 종료시 트랜젝션이 DB로 커밋, 예외 발생시 롤백
+	public FAQDTO findById(int faq_id) {
+		FAQDTO DTO = repo.findById(faq_id)
+		.orElseThrow(() -> new IllegalArgumentException("조회 오류")); 
+		//-> 는 람다식 (IllegalArgumentException 예외 객체를 생성하여 예외 발생, 오류메시지 출력)
+		return DTO;
+		
+	}
+	
+	// 수정
+	@Transactional  // 작업의 단위, 메서드 정상 종료시 트랜젝션이 DB로 커밋, 예외 발생시 롤백
+	public FAQDTO put(int qa_id, FAQDTO DTO) {
+		
+		FAQDTO DTOp = repo.findById(qa_id)
+				.orElseThrow(() -> new IllegalArgumentException("수정 오류")); //-> 는 람다식 (IllegalArgumentException 예외 객체를 생성하여 예외 발생, 오류메시지 출력)
+			// 엔티티의 값을 변경하면 자동으로 데이터베이스(DB)도 변경
+		DTOp.setAnswer(DTO.getAnswer());
+		DTOp.setQuestion(DTO.getQuestion());
+		return DTOp;
+	}
+}


### PR DESCRIPTION
## Motivation 🧐
<!--변경 사항 및 관련 이슈에 대한 설명란 -->
- json 데이터 파일을 파이썬의 with open과 mysql.connector를 이용하여 db에 저장 
- faq 질문, 답변 등록, 수정, 삭제, 목록 리액트 구현
- faq CRUD 스프링 부트 백앤드 구현
- 컬럼은 qa_id(PK), question, answer, created_at, updated_at, 관리자와 고객 모두가 보는 tb여서 fk 등록 안함
- 추후에 관리자 세션을 구분받아 수정, 삭제버튼이 답변창에서 관리자만 볼 수 있게 변경 (현재 목록 답변 창에서 모두 보임)
- 기존에 따로 나눈 수정 창을 FAQ 목록에서 개별적으로 삭제, 수정할 수 있도록 수정
- erp에서 useState로 변경되는 화면에서 사용하기 위해 reload함수가 아니라 useState로 수정 삭제 후 화면창 변경
<br>

## Key Changes 🔑
<!-- 어떤 변경사항이 있었는지?-->
- [X] 새로운 기능 추가
- [ ] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 추가(README.MD,,)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 커밋 수정 (reset/revert/rename..)
<br>

## To Reviewrs ✍🏻

기존 화면
FAQList
![스크린샷 2025-04-01 182653](https://github.com/user-attachments/assets/548ffa84-36b8-4763-9d58-95c4a1277f61)
기존화면
FAQPost
![image](https://github.com/user-attachments/assets/b0d08ac3-7da2-4fda-9409-847d2c320f8d)

기존 화면
FAQPut
![image](https://github.com/user-attachments/assets/250f8173-2fdb-44bd-8cde-7c3b017169c5)

FAQList - deleteCheck
![image](https://github.com/user-attachments/assets/941000c2-942d-4e24-bcbd-d28d4f217ca8)

 DB
![image](https://github.com/user-attachments/assets/ae04000a-7d8f-445a-80a7-0a6efde2d2f8)

수정 ( List+Put 통합)
FAQList
![image](https://github.com/user-attachments/assets/e040ded6-201a-4beb-aec8-82050e89180d)
FAQPOST
![image](https://github.com/user-attachments/assets/8ee4bae5-7d60-4118-85dc-5990873ccb98)

