### PR TITLE
[emp_login] Employee 로그인 구현

### DIFF
--- a/front-react/package.json
+++ b/front-react/package.json
@@ -16,6 +16,7 @@
     "blockly": "^11.2.2",
     "bootstrap": "^5.3.3",
     "formik": "^2.4.6",
+    "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-bootstrap": "^2.10.9",
     "react-dom": "^18.2.0",

--- a/front-react/src/common/Header.jsx
+++ b/front-react/src/common/Header.jsx
@@ -18,8 +18,15 @@ function Header() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    setIsLoggedIn(!!localStorage.getItem('accessToken'));
-    if (localStorage.getItem('accessToken')) {
+    const accessToken = localStorage.getItem('accessToken');
+    setIsLoggedIn(!!accessToken);
+    if (accessToken) {
+      try {
+        const decodedToken = jwtDecode(accessToken);
+        setUserRole(decodedToken.userType); // "CUSTOMER" 또는 "EMPLOYEE" 값
+      } catch (error) {
+        console.error('토큰 디코딩 실패:', error);
+      }
       axiosInstance.get('/auth/user')
         .then((response) => {
           setUser(response.data);
@@ -33,6 +40,21 @@ function Header() {
         });
     }
   }, [navigate]);
+  //   setIsLoggedIn(!!localStorage.getItem('accessToken'));
+  //   if (localStorage.getItem('accessToken')) {
+  //     axiosInstance.get('/auth/user')
+  //       .then((response) => {
+  //         setUser(response.data);
+  //       })
+  //       .catch((error) => {
+  //         console.error('사용자 정보 조회 실패:', error);
+  //         localStorage.removeItem('accessToken');
+  //         localStorage.removeItem('refreshToken');
+  //         setIsLoggedIn(false);
+  //         navigate('/login');
+  //       });
+  //   }
+  // }, [navigate]);
 
   const handleLogout = () => {
     axiosInstance.post('/auth/logout')

--- a/front-react/src/common/Header.jsx
+++ b/front-react/src/common/Header.jsx
@@ -8,11 +8,13 @@ import logo from '../imgs/TICO_logo_icon.png';
 import logo1 from '../imgs/TICO_logo.png';
 import './Header.css';
 import axiosInstance from '../pages/login/social/utils/axiosInstance';
+import {jwtDecode} from 'jwt-decode';
 
 function Header() {
   const token = localStorage.getItem('accessToken');
   const [isLoggedIn, setIsLoggedIn] = useState(!!token);
   const [user, setUser] = useState(null);
+  const [userRole, setUserRole] = useState(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -72,10 +74,12 @@ function Header() {
             </Offcanvas.Header>
             <Offcanvas.Body>
               <Nav className="justify-content-end flex-grow-1 pe-3">
+                {userRole === "EMPLOYEE" && (
                 <NavDropdown title="관리자ERP" id="offcanvasNavbarDropdown">
                   <NavDropdown.Item href="erpMain">관리자 ERP</NavDropdown.Item>
                 </NavDropdown>
-
+              )}
+              
                 <NavDropdown title="생각하기" id="offcanvasNavbarDropdown">
                   <NavDropdown.Item href="#action3">티코 학습하기</NavDropdown.Item>
                 </NavDropdown>

--- a/front-react/src/pages/login/Login.jsx
+++ b/front-react/src/pages/login/Login.jsx
@@ -6,7 +6,7 @@ import axiosInstance from "../login/social/utils/axiosInstance";
 function Login() {
   const [isLoggedIn, setIsLoggedIn] = useState(false); // 로그인 상태를 저장합니다. (로그인 되었으면 true, 아니면 false)
   const [userInfo, setUserInfo] = useState(null); // 로그인한 사용자의 정보를 저장합니다. (예: 이메일, 닉네임)
-  const [email, setEmail] = useState(""); // 로그인 폼에 입력하는 이메일 저장
+  const [loginId, setLoginId] = useState("");
   const [password, setPassword] = useState(""); // 로그인 폼에 입력하는 비밀번호 저장
   const navigate = useNavigate();
 
@@ -35,10 +35,19 @@ function Login() {
   const handleLogin = async (e) => {
     e.preventDefault();
     try {
-      console.log("baseURL:", axiosInstance.defaults.baseURL);
-      console.log("로그인 요청:", email);
-      const response = await axiosInstance.post("/auth/login", { email, password });
-
+      console.log("로그인 요청 ID:", loginId);
+      let endpoint = "";
+      let payload = {};
+      // 입력값에 '@'가 있으면 고객 로그인, 없으면 사원 로그인으로 분기
+      if (loginId.includes("@")) {
+        endpoint = "/auth/login/customer";
+        payload = { email: loginId, password };
+      } else {
+        endpoint = "/auth/login/employee";
+        // 사원 로그인은 EmpDTO에 정의된 필드명 사용 (empId, empPassword)
+        payload = { empId: loginId, emp_pwd: password };
+      }
+      const response = await axiosInstance.post(endpoint, payload);
       const { accessToken, refreshToken, user_uuid } = response.data;
       console.log("로그인 성공, 토큰 저장:", accessToken);
       localStorage.setItem("accessToken", accessToken);
@@ -108,10 +117,10 @@ function Login() {
           <>
             <div className="login-form">
               <input
-                type="email"
-                placeholder="이메일"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
+                type="text"
+                placeholder="이메일 또는 사원번호"
+                value={loginId}
+                onChange={(e) => setLoginId(e.target.value)}
                 required
               />
               <input

--- a/src/main/java/com/boot/tico/config/SecurityConfig.java
+++ b/src/main/java/com/boot/tico/config/SecurityConfig.java
@@ -13,6 +13,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import com.boot.tico.login.security.JwtAuthenticationFilter;
+
+import static org.springframework.security.config.Customizer.withDefaults;
 import com.boot.tico.login.security.OAuth2SuccessHandler;
 import com.boot.tico.login.security.UserDetailsServiceImpl;
 
@@ -23,23 +25,29 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
     
+	// JWT 필터 주입 (AccessToken 검증 필터)
     private final JwtAuthenticationFilter jwtFilter;
     
+    // Security 필터 체인 설정
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, OAuth2SuccessHandler successHandler) throws Exception {
-        http
-        .cors() // 자체적으로 CORS 필터 체인을 다루기 때문에, SecurityFilterChain에 .cors() 설정이 추가되어야 함
-        .and()
-        .csrf().disable()
-          .authorizeRequests()
-            .antMatchers("/auth/**", "/auth/login/**", "/oauth2/**", "/error", "/project/**", "/api/**", "/uploads/**", "/").permitAll()
-            .anyRequest().authenticated()
-        .and()
-           .oauth2Login()
-           // .loginPage("/auth/login")
-           .successHandler(successHandler)
-            .failureUrl("/auth/login?error=true");
-        // 로그아웃 설정은 제거하여 AuthController의 /auth/logout이 사용되도록 함.
+        http	
+        		// CORS 설정 활성화
+                .cors(withDefaults())
+                // CSRF 비활성화 (JWT 기반 API 인증에 필요 없음)
+                .csrf(csrf -> csrf.disable())
+                // 요청 권한 설정
+                .authorizeRequests(requests -> requests
+                		// 인증 없이 접근 허용할 경로들 (이외의 요청은 인증 필요)
+                        .antMatchers("/auth/**", "/auth/login/emp;oyee**", "/auth/login/customer**", "/oauth2/**", "/error", "/project/**", "/api/**", "/uploads/**", "/").permitAll()
+                        .anyRequest().authenticated())
+                // 소셜 로그인 설정
+                .oauth2Login(login -> login
+                        // 로그인 성공 시 커스텀 SuccessHandler 실행 (JWT 발급 등 처리)
+                        .successHandler(successHandler)
+                        // 실패시 리디랙션
+                        .failureUrl("/auth/login?error=true"));
+        // UsernamePasswordAuthenticationFilter 앞에 JWT 필터 삽입
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/boot/tico/erp/dto/EmpDTO.java
+++ b/src/main/java/com/boot/tico/erp/dto/EmpDTO.java
@@ -4,6 +4,8 @@ import java.math.BigDecimal;
 import java.util.Date;
 import javax.persistence.*;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -59,5 +61,10 @@ public class EmpDTO {
     @Temporal(TemporalType.DATE)
     @Column(name = "termination_date")
     private Date terminationDate;
+    
+    // 직원 로그인용 비밀번호 필드 (암호화된 값 저장)
+    @Column(name = "emp_pwd")
+    @JsonProperty("emp_pwd")
+    private String emp_pwd;
 
 }

--- a/src/main/java/com/boot/tico/erp/service/EmployeeAuthService.java
+++ b/src/main/java/com/boot/tico/erp/service/EmployeeAuthService.java
@@ -1,0 +1,62 @@
+package com.boot.tico.erp.service;
+
+import com.boot.tico.erp.dto.EmpDTO;
+import com.boot.tico.erp.repo.EmpRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmployeeAuthService {
+
+    private final EmpRepository empRepository;
+
+    // ✔ 개발용: 평문 비밀번호 비교 (운영환경 X)
+    public Optional<EmpDTO> authenticate(String empId, String rawPassword) {
+        Optional<EmpDTO> empOpt = empRepository.findById(empId);
+        if (empOpt.isPresent()) {
+            EmpDTO emp = empOpt.get();
+
+            // 👉 평문 비교
+            if (rawPassword.equals(emp.getEmp_pwd())) {
+                return Optional.of(emp);
+            } else {
+                log.warn("비밀번호 불일치: empId={}", empId);
+            }
+
+        } else {
+            log.warn("사원 정보 없음: empId={}", empId);
+        }
+        return Optional.empty();
+    }
+    
+    public Optional<EmpDTO> findByEmpId(String empId) {
+        return empRepository.findById(empId);
+    }
+}
+    
+    
+    
+//    private final PasswordEncoder passwordEncoder;
+//    
+//    // 입력된 empId와 비밀번호(rawPassword)를 검증하는 메서드
+//    public Optional<EmpDTO> authenticate(String empId, String rawPassword) {
+//        Optional<EmpDTO> empOpt = empRepository.findById(empId);
+//        if (empOpt.isPresent()) {
+//            EmpDTO emp = empOpt.get();
+//            if (passwordEncoder.matches(rawPassword, emp.getEmp_pwd())) {
+//                return Optional.of(emp);
+//            } else {
+//                log.warn("비밀번호 불일치: empId={}", empId);
+//            }
+//        } else {
+//            log.warn("사원 정보 없음: empId={}", empId);
+//        }
+//        return Optional.empty();
+//    }
+//}

--- a/src/main/java/com/boot/tico/login/controller/AuthController.java
+++ b/src/main/java/com/boot/tico/login/controller/AuthController.java
@@ -9,6 +9,8 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.bind.annotation.*;
 
+import com.boot.tico.erp.dto.EmpDTO;
+import com.boot.tico.erp.service.EmployeeAuthService;
 import com.boot.tico.login.dto.UserDto;
 import com.boot.tico.login.entity.User;
 import com.boot.tico.login.security.JwtTokenizer;
@@ -18,6 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import java.security.Principal;
 import java.util.Map;
+import java.util.Optional;
 
 @Slf4j // 로깅 쉽게 확인할 수 있는 Lombok 어노테이션
 @RestController  // 메서드들이 JSON 형태의 응답을 클라이언트에 반환 (인코딩된 코드)
@@ -28,8 +31,11 @@ public class AuthController {
     private final UserService userService; // 회원 관련 로직(회원가입, 조회, 수정, 탈퇴 등)을 처리
     private final JwtTokenizer jwtTokenizer; // JWT 토큰을 생성하고, 검증하는 역할
     private final AuthenticationManager authenticationManager; // 회원 로그인 처리 담당
+    
+    // 기존 EmployeeService 대신 인증용 EmployeeAuthService 주입
+    private final EmployeeAuthService employeeAuthService;
 
-    // 일반 회원가입 API
+    // 일반 사용자 회원가입
     // 사용자가 회원가입할 때 입력한 정보를 받아 DB에 저장
     @PostMapping("/register")
     public ResponseEntity<?> register(@RequestBody UserDto.Request request) {
@@ -52,10 +58,10 @@ public class AuthController {
         }
     }
 
-    // 로그인 API (일반 로그인)
+    // 일반 로그인 (이메일 + 비밀번호)
     // 사용자가 로그인할 때 이메일과 비밀번호를 받아서 인증한 후, JWT 토큰(Access Token, Refresh Token)을 발급합
-    @PostMapping("/login")
-    public ResponseEntity<UserDto.Response> login(@RequestBody UserDto.LoginRequest request) {
+    @PostMapping("/login/customer")
+    public ResponseEntity<UserDto.Response> loginCustomer(@RequestBody UserDto.LoginRequest request) {
         UsernamePasswordAuthenticationToken authToken = // 사용자가 입력한 이메일과 비밀번호를 담은 인증 토큰을 만듬
             new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
         authenticationManager.authenticate(authToken); 
@@ -65,7 +71,11 @@ public class AuthController {
             .orElseThrow(() -> new RuntimeException("User not found"));
         // 인증 성공 시, 이메일을 db에서 정보 조회
 
-        Map<String, Object> claims = Map.of("email", user.getEmail(), "user_uuid", user.getUser_uuid());
+        Map<String, Object> claims = Map.of(
+        		"email", user.getEmail(), 
+        		"user_uuid", user.getUser_uuid(),
+        		"userType","CUSTOMER"
+        );
         String accessToken = jwtTokenizer.generateAccessToken(claims);
         String refreshToken = jwtTokenizer.generateRefreshToken();
         // email,id를 claims에 담아서 jwtToken을 이용해 새로운 accessToken,refreshToken 발급
@@ -81,20 +91,66 @@ public class AuthController {
         return ResponseEntity.ok(response); // 성공 시 반환
     }
     
-    // 로그인한 사용자 정보 조회 (JWT의 principal 사용)
+    // 사원 로그인 (사전에 DB에 등록되어 있는 정보 기반 / 비밀번호 암호화 x)
+    // 내부 DTO를 사용하지 않고, ERP 모듈의 EmpDTO를 @RequestBody로 직접 받습니다.
+    @PostMapping("/login/employee")
+    public ResponseEntity<UserDto.Response> loginEmployee(@RequestBody EmpDTO empRequest) {
+        // empRequest에 empId와 empPassword가 포함되어 있어야 합니다.
+        Optional<EmpDTO> empOpt = employeeAuthService.authenticate(empRequest.getEmpId(), empRequest.getEmp_pwd());
+        if (empOpt.isEmpty()) {
+            throw new RuntimeException("Employee not found or invalid credentials");
+        }
+        EmpDTO emp = empOpt.get();
+        Map<String, Object> claims = Map.of(
+            "empId", emp.getEmpId(),
+            "userType", "EMPLOYEE"
+        );
+        String accessToken = jwtTokenizer.generateAccessToken(claims);
+        String refreshToken = jwtTokenizer.generateRefreshToken();
+
+        UserDto.Response response = new UserDto.Response();
+        response.setUser_uuid(emp.getEmpId());
+        response.setEmail(emp.getEmpEmail());
+        response.setAccessToken(accessToken);
+        response.setRefreshToken(refreshToken);
+
+        return ResponseEntity.ok(response);
+    }
+    
+    
+    
+    // 로그인 사용자 정보 조회 (고객,사원 통합 처리 / JWT의 principal 사용)
     @GetMapping("/user")
     public ResponseEntity<UserDto.Response> getUser(Principal principal) {
-        String email = principal.getName(); // 현재 로그인한 사용자의 이메일을 얻음
-        // Principal principal : Security에서 인증된 사용자 정보를 담은 객체
-        log.debug("컨트롤러에서 받은 사용자 이메일: {}", email);
-        if (email == null) {
-            throw new RuntimeException("이메일이 null입니다! SecurityContext에 등록되지 않았습니다.");
+        String identity = principal.getName();
+        log.debug("현재 인증된 사용자: {}", identity);
+
+        // 일반 유저 찾기 (email로 찾기)
+        Optional<User> userOpt = userService.findByEmail(identity);
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+            return ResponseEntity.ok(createUserResponse(user));
         }
-        User user = userService.findByEmail(email)
-            .orElseThrow(() -> new RuntimeException("User not found"));
-        return ResponseEntity.ok(createUserResponse(user));
-        // 조회된 정보를 createUserResponse를 통해 jwt 토큰과 함께 응답 객체로 만들어 반환함
+
+        // 사원 찾기 (employee empId로 찾기)
+        Optional<EmpDTO> empOpt = employeeAuthService.findByEmpId(identity);
+        if (empOpt.isPresent()) {
+            EmpDTO emp = empOpt.get();
+
+            UserDto.Response res = new UserDto.Response();
+            res.setUser_uuid(emp.getEmpId());
+            res.setEmail(emp.getEmpEmail());
+            res.setName(emp.getEmpName());
+            res.setPhone(emp.getEmpPhone());
+            res.setProvider("employee"); // 선택사항
+
+            return ResponseEntity.ok(res);
+        }
+
+        // 3. 아무것도 못 찾으면 예외
+        throw new RuntimeException("User not found");
     }
+
     
     // 회원정보 수정 
     @PutMapping("/user")
@@ -116,7 +172,7 @@ public class AuthController {
     }
     
 
-    // 로그아웃 API
+    // 로그아웃 처리
     // 사용자가 로그아웃할 때, 현재 세션을 무효화하여 로그아웃 처리
     @PostMapping("/logout")
     
@@ -157,7 +213,12 @@ public class AuthController {
 
     // JWT 토큰을 포함한 응답 객체 생성 메서드
     private UserDto.Response createUserResponse(User user) {
-        Map<String, Object> claims = Map.of("email", user.getEmail(), "user_uuid", user.getUser_uuid());
+        Map<String, Object> claims = Map.of(
+        		"email", user.getEmail(),
+        		"user_uuid", user.getUser_uuid(),
+        		"userType", "CUSTOMER"
+        );
+        		
         String accessToken = jwtTokenizer.generateAccessToken(claims);
         String refreshToken = jwtTokenizer.generateRefreshToken();
 

--- a/src/main/java/com/boot/tico/login/dto/UserDto.java
+++ b/src/main/java/com/boot/tico/login/dto/UserDto.java
@@ -3,41 +3,40 @@ package com.boot.tico.login.dto;
 import lombok.Getter;
 import lombok.Setter;
 
-/*
-  UserDto 클래스는 일반 회원가입과 소셜 회원가입 모두에서 사용되며,
-  소셜 가입 시 추가적으로 provider와 providerId 필드를 전달합니다.
-*/
 public class UserDto {
+
+    // ✅ 회원가입/수정 요청 DTO
     @Getter
     @Setter
     public static class Request {
-        private String email;
-        private String password; // 일반 가입 시 필요, 소셜 가입은 null
-        private String phone;
-        private String name;
-        private String nickname;
-        // 소셜 가입 시 사용 (local이 아니면 소셜 가입)
-        private String provider;
-        private String providerId;
+        private String email;       // 사용자 이메일
+        private String password;    // 사용자 비밀번호
+        private String name;        // 이름
+        private String nickname;    // 닉네임
+        private String phone;       // 연락처
+        private String provider;    // 소셜 로그인 공급자 (google, kakao 등)
+        private String providerId;  // 소셜 로그인 고유 ID
     }
 
+    // ✅ 로그인 요청 DTO
     @Getter
     @Setter
     public static class LoginRequest {
-        private String email;
-        private String password;
+        private String email;       // 일반 로그인 시 이메일
+        private String password;    // 일반 로그인 시 비밀번호
     }
 
+    // ✅ 응답 DTO (공통으로 사용)
     @Getter
     @Setter
     public static class Response {
-        private String user_uuid;
-        private String email;
-        private String name;
-        private String nickname;
-        private String phone;
-        private String provider;
-        private String accessToken;
-        private String refreshToken;
+        private String user_uuid;      // 유저 고유 식별자 (또는 empId)
+        private String email;          // 이메일
+        private String name;           // 이름
+        private String nickname;       // 닉네임
+        private String phone;          // 전화번호
+        private String provider;       // 로그인 방식 구분자 (local, naver, kakao 등)
+        private String accessToken;    // JWT Access Token
+        private String refreshToken;   // JWT Refresh Token
     }
 }

--- a/src/main/java/com/boot/tico/login/main/main.java
+++ b/src/main/java/com/boot/tico/login/main/main.java
@@ -1,0 +1,15 @@
+package com.boot.tico.login.main;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class main implements CommandLineRunner{
+	 @Override
+	    public void run(String... args) throws Exception {
+	        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+	        String encodedPassword = encoder.encode("123456");
+	        System.out.println("Encoded password: " + encodedPassword);
+	    }
+	}

--- a/src/main/java/com/boot/tico/login/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/boot/tico/login/security/JwtAuthenticationFilter.java
@@ -37,13 +37,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(token)) {
             try {
                 Claims claims = jwtTokenizer.parseClaims(token);
-                String email = claims.get("email", String.class);
-                log.debug("토큰에서 추출된 이메일: {}", email);
+                // 우선 email 클레임이 있는지 먼저 확인하고, 없으면 empId 클레임 사용
+                String principal;
+                if(claims.containsKey("email")) {
+                	principal = claims.get("email", String.class);
+                } else if(claims.containsKey("empId")) {
+                	principal = claims.get("empId", String.class);
+                } else {
+                	principal = null;
+                }
+                
+                log.debug("토큰에서 추출된 이메일: {}", principal);
 
-                if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-                    log.debug("JWT 필터에서 추출한 이메일: {}", email); 
+                if (principal != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                    log.debug("JWT 필터에서 추출한 이메일: {}", principal); 
                     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                            email, null, Collections.emptyList());
+                    		principal, null, Collections.emptyList());
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
             } catch (ExpiredJwtException e) {


### PR DESCRIPTION
## Motivation 🧐
✅ Spring Boot + JWT 기반 EMPLOYEE(사원) 로그인 구현
📌 개요
이 프로젝트에서는 Spring Security + JWT를 사용하여
일반 사용자 / 소셜 로그인 외에,
사원(Employee) 전용 로그인을 회원가입 없이 DB에 등록된 값으로 바로 로그인하는 기능을 구현완료

⚠️ 운영 환경에서는 emp_pwd에 반드시 BCrypt 암호화를 적용해야 합니다.
현재는 테스트를 위해 평문으로 비교합니다
- **현재 테스트를 위해 BCrypt 암호화 되지않은 상태로 Maria db에서 직접 insert를 통해 지정한 emp_id / emp_pwd
  값으로 로그인 하기에 추후 운영 환경에서는 암호화필수!**

🔐 로그인 방식
일반 로그인은 이메일(email), 소셜 로그인은 providerId로 인증
employee 로그인은 empId + emp_pwd 조합으로 로그인
로그인 창은 모두 같은 화면에서 처리

📌 결론
EMPLOYEE 로그인은 회원가입 없이 DB에 등록된 값으로 바로 로그인하는 구조
일반/소셜 로그인과 같은 JWT 기반 인증 구조를 유지
토큰 발급/유형 구분/프론트 처리도 동일하게 사용 가능

<br>

## Key Changes 🔑
<!-- 어떤 변경사항이 있었는지?-->
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 추가(README.MD,,)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 커밋 수정 (reset/revert/rename..)
<br>

## To Reviewrs ✍🏻
![image](https://github.com/user-attachments/assets/8286a796-1f3b-4096-ab66-b1b30fa079a2)
![image](https://github.com/user-attachments/assets/0da50f7b-f95f-474b-9120-942fdea65e43)

- header 일반/소셜 로그인과 다르게 관리자ERP 메뉴 확인됨
