### PR TITLE
[header-identify] 사원/일반 회원 별 헤더 구현

### DIFF
--- a/front-react/src/common/Header.jsx
+++ b/front-react/src/common/Header.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Button, Container, Form, Nav, Navbar, NavDropdown, Offcanvas } from 'react-bootstrap';
+import { Button, Container, Dropdown, Form, Nav, Navbar, NavDropdown, Offcanvas } from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
@@ -8,7 +8,7 @@ import logo from '../imgs/TICO_logo_icon.png';
 import logo1 from '../imgs/TICO_logo.png';
 import './Header.css';
 import axiosInstance from '../pages/login/social/utils/axiosInstance';
-import {jwtDecode} from 'jwt-decode';
+
 
 function Header() {
   const token = localStorage.getItem('accessToken');
@@ -18,15 +18,8 @@ function Header() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const accessToken = localStorage.getItem('accessToken');
-    setIsLoggedIn(!!accessToken);
-    if (accessToken) {
-      try {
-        const decodedToken = jwtDecode(accessToken);
-        setUserRole(decodedToken.userType); // "CUSTOMER" 또는 "EMPLOYEE" 값
-      } catch (error) {
-        console.error('토큰 디코딩 실패:', error);
-      }
+    setIsLoggedIn(!!localStorage.getItem('accessToken'));
+    if (localStorage.getItem('accessToken')) {
       axiosInstance.get('/auth/user')
         .then((response) => {
           setUser(response.data);
@@ -40,22 +33,6 @@ function Header() {
         });
     }
   }, [navigate]);
-
-  //   setIsLoggedIn(!!localStorage.getItem('accessToken'));
-  //   if (localStorage.getItem('accessToken')) {
-  //     axiosInstance.get('/auth/user')
-  //       .then((response) => {
-  //         setUser(response.data);
-  //       })
-  //       .catch((error) => {
-  //         console.error('사용자 정보 조회 실패:', error);
-  //         localStorage.removeItem('accessToken');
-  //         localStorage.removeItem('refreshToken');
-  //         setIsLoggedIn(false);
-  //         navigate('/login');
-  //       });
-  //   }
-  // }, [navigate]);
 
   const handleLogout = () => {
     axiosInstance.post('/auth/logout')
@@ -98,6 +75,7 @@ function Header() {
             </Offcanvas.Header>
             <Offcanvas.Body>
               <Nav className="justify-content-end flex-grow-1 pe-3">
+               
                 <NavDropdown title="생각하기" id="offcanvasNavbarDropdown">
                   <NavDropdown.Item href="#action3">티코 학습하기</NavDropdown.Item>
                 </NavDropdown>
@@ -127,20 +105,31 @@ function Header() {
               {/* 로그인 상태에 따라 로그인/로그아웃 버튼 전환 */}
               {isLoggedIn ? (
                 <>
-                <Button
-                  className="button-mapage"
-                  variant="outline-primary"
-                  onClick={() => navigate('/MypageMain')}
-                  style={{ marginRight: '10px'}}
-                  >
-                    Mypage
-                  </Button>
+                  {/* 드롭다운을 사용하여 클릭 시 Mypage가 보이도록 구성 */}
+                  <Dropdown style={{ marginRight: '10px' }}>
+                    <Dropdown.Toggle
+                      variant="light"
+                      id="dropdown-basic"
+                      style={{ color: 'black' }}
+                    >
+                      { 
+                        user 
+                          ? (user.provider === 'employee' ? user.user_uuid : user.email) 
+                          : "My Account"
+                      }
+                    </Dropdown.Toggle>
 
-                  {/* user가 있을 경우, 이메일 표시 */}
-                  <span style={{ marginRight: '10px' }}>{user?.email}</span>
-                  <Button className='button2' variant="outline-danger" onClick={handleLogout}>
-                    로그아웃
-                  </Button>
+                    <Dropdown.Menu>
+                      <Dropdown.Item onClick={() => navigate('/MypageMain')}>
+                        Mypage
+                      </Dropdown.Item>
+                      {/* 필요시 추가 메뉴 아이템 */}
+                    </Dropdown.Menu>
+                  </Dropdown>
+                  
+                <Button className='button2' variant="outline-danger" onClick={handleLogout}>
+                  로그아웃
+                </Button>
                 </>
               ) : (
                 <Button className='button1' variant="outline-success" onClick={handleLogin}>


### PR DESCRIPTION
## Motivation 🧐

🔧 Header 드롭다운 기능 및 사용자 유형별 표시 개선
주요 변경 사항
react-bootstrap의 Dropdown을 사용하여 사용자 정보 드롭다운 메뉴 추가

로그인한 사용자에 따라 드롭다운에 표시되는 내용이 다르게 렌더링 되도록 구현

일반/소셜 로그인 사용자: 이메일(email) 표시

사원 로그인 사용자: 사원번호(emp_id) 표시

🧑‍💻 구현 상세
로그인 상태일 경우:

user.provider 값이 'employee'인 경우 → emp_id 출력

그 외(일반/소셜 로그인) → user.email 출력

드롭다운 메뉴 클릭 시 /MypageMain으로 이동

우측에 로그아웃 버튼 함께 배치

<br>

## Key Changes 🔑
<!-- 어떤 변경사항이 있었는지?-->
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 추가(README.MD,,)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 커밋 수정 (reset/revert/rename..)
<br>

## To Reviewrs ✍🏻
![image](https://github.com/user-attachments/assets/af6da746-862b-4c7a-ac2c-b368fa5f7aa8)
