### PR TITLE
[Localhost code kyj1] 🔔 관리자 알림 기능 추가

### DIFF
--- a/front-react/src/blockly/components/ObjectSelectPage.jsx
+++ b/front-react/src/blockly/components/ObjectSelectPage.jsx
@@ -3,7 +3,7 @@ import { Container, Sidebar, Sidenav, Nav, Content, Header, ButtonGroup, Button,
 import 'rsuite/dist/rsuite.min.css';
 import './objectSelectPage.css';
 import axiosInstance from '../../pages/login/social/utils/axiosInstance';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { jwtDecode } from 'jwt-decode';
 
 // 아이콘
@@ -17,6 +17,7 @@ import { SiLinuxcontainers } from "react-icons/si";
 import ObjectUploader from './ObjectUploader';
 import ObjectDraw from './ObjectDraw';
 import ObjectTextbox from './ObjectTextbox';
+import PurchasePage from '../../mypage/PurchasePage';
 
 // ObjectSelectPage.jsx
 // 블록 오브젝트 선택 및 관리(등록, 수정, 삭제, 업로드 등)를 담당하는 메인 컴포넌트
@@ -29,9 +30,7 @@ function ObjectSelectPage({ onComplete }) {
   const [selectedObjects, setSelectedObjects] = useState([]);         // 선택된 오브젝트
   const [activeMode, setActiveMode] = useState('object');             // 모드 상태(object, upload, draw, textbox)
   const userUuid = localStorage.getItem("user_uuid");                 // 현재 로그인된 사용자 UUID
-  const [showPurchaseModal, setShowPurchaseModal] = useState(false);  // 결제 모달 상태 정의
-
-  const navigate = useNavigate();
+  const [showPurchasePageModal, setShowPurchasePageModal] = useState(false);  // 결제 페이지 모달로 띄우기
 
   // 구매 완료 여부 확인
   const location = useLocation();
@@ -296,22 +295,27 @@ function ObjectSelectPage({ onComplete }) {
 
     <Container className="objectSelectPage-container">
 
-      {/* 결제 모달창 */}
-      <Modal open={showPurchaseModal} onClose={() => setShowPurchaseModal(false)}>
-        <Modal.Header>
-          <Modal.Title>이용권이 필요합니다</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          이 오브젝트는 유료입니다. 이용권을 구매하시겠습니까?
-        </Modal.Body>
-        <Modal.Footer>
-          <Button appearance="primary" onClick={() => {
-            setShowPurchaseModal(false);
-            navigate('/purchase'); // 👉 원하는 결제 페이지 URL
-          }}>예</Button>
-          <Button appearance="subtle" onClick={() => setShowPurchaseModal(false)}>아니오</Button>
-        </Modal.Footer>
-      </Modal>
+<Modal
+  open={showPurchasePageModal}
+  onClose={() => setShowPurchasePageModal(false)}
+  size="sm"
+  backdrop="static"
+  keyboard={false}
+>
+  <Modal.Header>
+    <Modal.Title>프리미엄 이용권 구매</Modal.Title>
+  </Modal.Header>
+  <Modal.Body>
+    <PurchasePage
+      goToStatus={() => {
+        setShowPurchasePageModal(false);
+        setIsPurchased(true);      // ✅ 결제 완료 후 락 해제
+        fetchObjectList();         // ✅ 최신 오브젝트 목록 재로드
+      }}
+    />
+  </Modal.Body>
+</Modal>
+
 
       {/* 오브젝트 등록, 수정 모달창 */}
       <Modal open={showModal} onClose={() => {
@@ -497,7 +501,7 @@ function ObjectSelectPage({ onComplete }) {
                       className={`objectSelectPage-item ${(isPaid && !isPurchased && !isAdmin) ? 'locked' : ''}`}
                       onClick={() => {
                         if (isPaid && !isPurchased && !isAdmin) {
-                          setShowPurchaseModal(true);   // 유료 + 미결제인 경우만 모달
+                          setShowPurchasePageModal(true); // ✅ 결제 페이지 모달 띄움
                           return;
                         }
                         handleSelectObject(obj);         // 무료거나 결제했으면 바로 선택

--- a/front-react/src/common/Header.jsx
+++ b/front-react/src/common/Header.jsx
@@ -8,7 +8,7 @@ import logo from '../imgs/TICO_logo_icon.png';
 import logo1 from '../imgs/TICO_logo.png';
 import './Header.css';
 import axiosInstance from '../pages/login/social/utils/axiosInstance';
-
+import NotificationDropdown from './NotificationDropdown';
 
 function Header() {
   const token = localStorage.getItem('accessToken');
@@ -111,31 +111,25 @@ function Header() {
               {/* 로그인 상태에 따라 로그인/로그아웃 버튼 전환 */}
               {isLoggedIn ? (
                 <>
-                  {/* 드롭다운을 사용하여 클릭 시 Mypage가 보이도록 구성 */}
-                  <Dropdown style={{ marginRight: '10px' }}>
-                    <Dropdown.Toggle
-                      variant="light"
-                      id="dropdown-basic"
-                      style={{ color: 'black' }}
-                    >
-                      { 
-                        user 
-                          ? (user.provider === 'employee' ? user.user_uuid : user.email) 
-                          : "My Account"
-                      }
-                    </Dropdown.Toggle>
-
-                    <Dropdown.Menu>
-                      <Dropdown.Item onClick={() => navigate('/MypageMain')}>
-                        Mypage
-                      </Dropdown.Item>
-                      {/* 필요시 추가 메뉴 아이템 */}
-                    </Dropdown.Menu>
-                  </Dropdown>
-                  
-                <Button className='button2' variant="outline-danger" onClick={handleLogout}>
-                  로그아웃
-                </Button>
+                  {user?.provider === 'employee' ? (
+                    <NotificationDropdown 
+                    userUuid={user.user_uuid} 
+                    onAllViewClick={() => navigate("/main?view=notifications")}/>
+                  ) : (
+                    <Dropdown style={{ marginRight: '10px' }}>
+                      <Dropdown.Toggle variant="light" style={{ color: 'black' }}>
+                        {user?.email || 'My Account'}
+                      </Dropdown.Toggle>
+                      <Dropdown.Menu>
+                        <Dropdown.Item onClick={() => navigate('/MypageMain')}>
+                          Mypage
+                        </Dropdown.Item>
+                      </Dropdown.Menu>
+                    </Dropdown>
+                  )}
+                  <Button className='button2' variant="outline-danger" onClick={handleLogout}>
+                    로그아웃
+                  </Button>
                 </>
               ) : (
                 <Button className='button1' variant="outline-success" onClick={handleLogin}>

--- a/front-react/src/common/NotificationDropdown.jsx
+++ b/front-react/src/common/NotificationDropdown.jsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import { Dropdown } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
+import axiosInstance from '../pages/login/social/utils/axiosInstance';
+import './notificationDropdown.css';
+
+function NotificationDropdown({ userUuid }) {
+  const [notifications, setNotifications] = useState([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (userUuid) {
+      fetchNotifications();
+    }
+  }, [userUuid]);
+
+  const fetchNotifications = async () => {
+    try {
+      const res = await axiosInstance.get(`/api/notifications/${userUuid}`);
+      const data = res.data || [];
+      setNotifications(data);
+
+      const personalUnread = data.filter(n => n.empId !== 'ALL' && !n.isRead).length;
+      const globalUnread = data.filter(n => n.empId === 'ALL' && !n.readByCurrentUser).length;
+      setUnreadCount(personalUnread + globalUnread);
+    } catch (err) {
+      console.error('알림 조회 실패:', err);
+    }
+  };
+
+  const handleNotificationClick = async (noti) => {
+    try {
+      await axiosInstance.post(`/api/notifications/read/${noti.notificationId}/${userUuid}`);
+    
+      // 📌 읽은 알림을 상태에서 바로 반영
+      setNotifications(prev =>
+        prev.map(n => {
+          if (n.notificationId === noti.notificationId) {
+            // 개인 알림
+            if (n.empId !== 'ALL') return { ...n, isRead: true };
+            // 글로벌 알림
+            else return { ...n, readByCurrentUser: true };
+          }
+          return n;
+        })
+      );
+
+      // 🔁 알림 수 재계산
+      setUnreadCount(prev => prev - 1);
+
+      // 이동 처리
+      if (noti.relatedType === 'notice') {
+        navigate(`/erpMain?view=detail&id=${noti.relatedId}`);
+      } else if (noti.relatedType === 'schedule') {
+        alert(`📌 일정 제목: ${noti.notificationTitle.replace('[일정] 마감 예정: ', '')}`);
+      } else if (noti.linkUrl) {
+        navigate(noti.linkUrl);
+      }
+    } catch (err) {
+      console.error('알림 읽음 처리 실패:', err);
+    }
+  };
+
+  const isNotificationUnread = (noti) => {
+    if (noti.empId === 'ALL') return !noti.readByCurrentUser;
+    return !noti.isRead;
+  };
+
+  return (
+    <Dropdown align="end" className="notification-dropdown">
+      <Dropdown.Toggle variant="light" id="notification-dropdown-toggle" style={{ position: 'relative' }}>
+        🔔
+        {unreadCount > 0 && (
+          <span className="notification-badge">{unreadCount}</span>
+        )}
+      </Dropdown.Toggle>
+
+      <Dropdown.Menu className="notification-dropdown-menu">
+        <Dropdown.Header>최근 알림</Dropdown.Header>
+        {notifications.length === 0 ? (
+          <Dropdown.ItemText className="text-muted">알림이 없습니다.</Dropdown.ItemText>
+        ) : (
+          notifications.slice(0, 3).map((noti) => (
+            <Dropdown.Item
+              key={noti.notificationId}
+              onClick={() => handleNotificationClick(noti)}
+              style={{ fontWeight: isNotificationUnread(noti) ? 'bold' : 'normal' }}
+            >
+              {noti.notificationTitle}
+              <br />
+              <small className="text-muted">
+                {new Date(noti.createdAt).toLocaleDateString()}
+              </small>
+            </Dropdown.Item>
+          ))
+        )}
+        <Dropdown.Divider />
+        <Dropdown.Item onClick={() => navigate('/erpMain?view=notifications')}>
+          🔎 알림 모두 보기
+        </Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+}
+
+export default NotificationDropdown;

--- a/front-react/src/common/notificationDropdown.css
+++ b/front-react/src/common/notificationDropdown.css
@@ -1,0 +1,37 @@
+/* 알림 뱃지 스타일 */
+.notification-dropdown .notification-badge {
+  position: absolute;
+  top: -3px;
+  right: -5px;
+  width: 16px;
+  height: 16px;
+  background-color: red;
+  color: white;
+  font-size: 10px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1; /* (선택) 혹시 겹치는 문제 있을까봐 추가 */
+}
+
+/* 알림 드롭다운 메뉴 스타일 */
+.notification-dropdown-menu {
+  min-width: 300px;
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 8px 0; /* 살짝 여백 주기 */
+  font-size: 14px; /* 보기 좋은 기본 폰트 사이즈 */
+}
+
+/* (선택) 알림 항목 구분선 */
+.notification-dropdown-menu .dropdown-divider {
+  margin: 4px 0;
+}
+
+/* (선택) 알림이 없을 때 텍스트 */
+.notification-dropdown-menu .text-muted {
+  font-size: 13px;
+  padding: 10px;
+  text-align: center;
+}

--- a/front-react/src/mypage/PurchasePage.jsx
+++ b/front-react/src/mypage/PurchasePage.jsx
@@ -2,11 +2,9 @@ import React, { useEffect, useState } from 'react';
 import './purchasePage.css';
 import { Button, Panel, Message } from 'rsuite';
 import axiosInstance from '../pages/login/social/utils/axiosInstance';
-import { useNavigate } from 'react-router-dom';
 
 function PurchasePage({ goToStatus }) {
   const userUuid = localStorage.getItem('user_uuid');
-  const navigate = useNavigate(); 
 
   const [isPaying, setIsPaying] = useState(false);
   const [status, setStatus] = useState('IDLE');   // PAID / FAILED / IDLE
@@ -67,7 +65,7 @@ function PurchasePage({ goToStatus }) {
           setStatus("PAID");
           setAlreadySubscribed(true); // UI 업데이트
           if (goToStatus) {
-            navigate('/object-select', { state: { purchased: true } });  
+            goToStatus();
           }
         } catch (error) {
           console.error("❌ 서버 검증 실패:", error);

--- a/front-react/src/mypage/SubscriptionState.jsx
+++ b/front-react/src/mypage/SubscriptionState.jsx
@@ -1,48 +1,56 @@
 import React, { useEffect, useState } from "react";
 import "./subscriptionState.css";
-import { Button, Tag, Loader, Message, ButtonToolbar, Modal } from "rsuite";
+import { Button, Tag, Loader, Message, ButtonToolbar } from "rsuite";
 import axiosInstance from "../pages/login/social/utils/axiosInstance";
-import ReceiptModal from "./ReceiptModal";  // 영수증
+import ReceiptModal from "./ReceiptModal";
 
 function SubscriptionState({ goToPurchase }) {
   const [subscription, setSubscription] = useState(null);
-  const [loading, setLoading] = useState(true);
-
-  const [showReceipt, setShowReceipt] = useState(false);
   const [receiptData, setReceiptData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [showReceipt, setShowReceipt] = useState(false);
 
   useEffect(() => {
-    const fetchSubscription = async () => {
-      try {
-        const userUuid = localStorage.getItem("user_uuid");
-        const res = await axiosInstance.get(`/api/purchase/${userUuid}`);
-        console.log("🎫 구독 응답:", res.data);
-
-        setSubscription(res.data);
-
-        // 영수증 데이터도 미리 가져오기
-        const receiptRes = await axiosInstance.get(`/api/purchase/receipt-data/${userUuid}`);
-        setReceiptData(receiptRes.data);
-      } catch (err) {
-        console.error("❌ 구독 정보 불러오기 실패:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchSubscription();
+    fetchSubscriptionData();
   }, []);
 
-  // 날짜 포맷 함수
+  const fetchSubscriptionData = async () => {
+    try {
+      const userUuid = localStorage.getItem("user_uuid");
+
+      // ✅ 1. 이용권 정보 요청
+      const res = await axiosInstance.get(`/api/purchase/${userUuid}`);
+      setSubscription(res.data);
+
+      // ✅ 2. 영수증 정보 요청 (404 예외만 따로 처리)
+      try {
+        const receiptRes = await axiosInstance.get(`/api/purchase/receipt-data/${userUuid}`);
+        setReceiptData(receiptRes.data);
+      } catch (receiptErr) {
+        if (receiptErr.response?.status === 404) {
+          console.log("ℹ️ 영수증 없음 (최근 결제 기록 없음)");
+        } else {
+          console.error("❌ 영수증 조회 실패:", receiptErr);
+        }
+        setReceiptData(null); // 명시적으로 null 처리
+      }
+
+    } catch (err) {
+      console.error("❌ 이용권 정보 조회 실패:", err);
+      setSubscription(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const formatDate = (isoDate) => {
     return new Date(isoDate).toLocaleDateString("ko-KR", {
       year: "numeric",
       month: "2-digit",
-      day: "2-digit",
+      day: "2-digit"
     });
   };
 
-  // 영수증 보기 버튼 클릭
   const handleOpenReceipt = () => {
     if (!receiptData) {
       alert("영수증 정보를 불러올 수 없습니다.");
@@ -61,7 +69,11 @@ function SubscriptionState({ goToPurchase }) {
         ) : subscription ? (
           <>
             <div className="subscription-info">
-              상태{subscription.active ? <Tag color="green">사용 중</Tag> : <Tag color="red">만료됨</Tag>}<br />
+              상태 {subscription.active ? (
+                <Tag color="green">사용 중</Tag>
+              ) : (
+                <Tag color="red">만료됨</Tag>
+              )}<br />
               구매일 {formatDate(subscription.startDate)}<br />
               만료일 {formatDate(subscription.endDate)}<br />
               이용권 종류 {subscription.subscriptionType}<br />
@@ -75,12 +87,11 @@ function SubscriptionState({ goToPurchase }) {
               </Button>
             </ButtonToolbar>
 
-            {/* 항상 보여지는 안내 메시지 */}
             <Message type="warning" className="subscription-note">
               이용권 환불은 고객센터 또는 관리자에게 문의해주세요. <br />
               010-4682-4882 / anzngksduswn@naver.com
             </Message>
-            {/* ✅ 모달 컴포넌트 */}
+
             <ReceiptModal
               open={showReceipt}
               onClose={() => setShowReceipt(false)}

--- a/front-react/src/pages/erp/ErpMain.jsx
+++ b/front-react/src/pages/erp/ErpMain.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { Content, Footer, Header, Nav, Sidenav } from "rsuite";
+import { useLocation } from "react-router-dom";
+import { Content, Footer, Nav, Sidenav } from "rsuite";
 import "rsuite/dist/rsuite.min.css";
 import "./erpMain.css";
 
@@ -35,6 +36,7 @@ import PurchaseLogPage from "./PAY_Team/PurchaseLogPage";
 import EMPEduList from "../blockedu/EMPEduList";
 import NoticeAdmin from "../notice/NoticeAdmin";
 import axiosInstance from "../login/social/utils/axiosInstance";
+import NotificationList from "./MyPage/NotificationList";
 
 function ErpMain() {
   const [expanded, setExpanded] = useState(true); // 사이드바 확장 여부
@@ -43,6 +45,17 @@ function ErpMain() {
   const [comNotiId, setComNotiId] = useState(null); // 상세/수정 대상 ID
   const [empInfo, setEmpInfo] = useState(null); // 로그인된 사원 정보 상태(초기값 null)
   const [selectedUserId, setSelectedUserId] = useState(null); // 유저 상세 페이지용
+
+  // URL 쿼리파라미터
+  const location = useLocation();
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const viewParam = params.get('view');
+    const idParam = params.get('id');
+
+    if (viewParam) setViewMode(viewParam);
+    if (idParam) setComNotiId(idParam);
+  }, [location.search]);
 
   // 컴포넌트 마운트 시(처음 렌더링 시) 사원 정보를 서버에서 불러오는 useEffect
   useEffect(() => {
@@ -100,8 +113,6 @@ function ErpMain() {
 
   return (
     <div className="erp-main-container">
-      <Header></Header>
-
       {/* 좌측 사이드바 + 우측 메인 콘텐츠 */}
       <div className="content-wrapper">
         {/* 사이드바 영역 */}
@@ -135,7 +146,7 @@ function ErpMain() {
                 >
                   <Nav.Item eventKey="3-1">관리자 등록</Nav.Item>
                   <Nav.Item eventKey="3-2">관리자 조회/수정/삭제</Nav.Item>
-                </Nav.Menu>     
+                </Nav.Menu>
 
                 {/* 결제 관리팀 메뉴 (DEP002 부서만 활성화) */}
                 <Nav.Menu
@@ -174,7 +185,7 @@ function ErpMain() {
                   <Nav.Item eventKey="6-4">환불/취소 문의 관리</Nav.Item>
                   <Nav.Item eventKey="6-5">공지사항 관리</Nav.Item>
                   <Nav.Item eventKey="6-6">FAQ 관리</Nav.Item>
-                  
+
                 </Nav.Menu>
 
                 {/* 콘텐츠 관리팀 메뉴 (DEP005 부서만 활성화) */}
@@ -287,14 +298,15 @@ function ErpMain() {
             {viewMode === "myinfoChk" && <MyInfoChk />} {/* 관리자 정보 조회 */}
             {viewMode === "myinfoModify" && <MyInfoModify />} {/* 관리자 정보 조회 */}
             {viewMode === "notice" && <NoticeAdmin />} {/* 공지사항 관리 */}
+            {viewMode === "notifications" && <NotificationList/>} {/* 알림 정보 조회 */}
             {viewMode === "faq" && <FAQPut />} {/* FAQ 관리 */}
             {viewMode === "blockEduPost" && <BlockEduComponentPost />} {/* 블럭 학습 등록 */}
-            {viewMode === "EMPEduList" && <EMPEduList/>} {/* 블록학습 관리 */}
-            {viewMode === "ObjectSelectPage" && <ObjectSelectPage/>} {/* 오브젝트 관리 */}
-            {viewMode === "MainModify" && <MainModify/>} {/* 메인화면 */}
+            {viewMode === "EMPEduList" && <EMPEduList />} {/* 블록학습 관리 */}
+            {viewMode === "ObjectSelectPage" && <ObjectSelectPage />} {/* 오브젝트 관리 */}
+            {viewMode === "MainModify" && <MainModify />} {/* 메인화면 */}
 
-            {viewMode === "subscription-manage" && <SubscriptionManager/>} {/* 결제 회원 관리 */}
-            {viewMode === "purchaseLog" && <PurchaseLogPage/>} {/* 결제 내역 로그 관리 */}
+            {viewMode === "subscription-manage" && <SubscriptionManager />} {/* 결제 회원 관리 */}
+            {viewMode === "purchaseLog" && <PurchaseLogPage />} {/* 결제 내역 로그 관리 */}
           </div>
         </Content>
       </div>

--- a/front-react/src/pages/erp/Home/ErpNotiDetail.jsx
+++ b/front-react/src/pages/erp/Home/ErpNotiDetail.jsx
@@ -3,6 +3,10 @@ import './erpNotiDetail.css';
 import axiosInstance from '../../login/social/utils/axiosInstance';
 
 function ErpNotiDetail({ id, onBack, onEdit }) {
+    
+    // 현재 로그인된 사번 가져오기
+    const currentEmpId = localStorage.getItem('user_uuid');
+
     // 공지사항 데이터를 담을 상태 변수
     const [notice, setNotice] = useState(null);
 
@@ -75,7 +79,10 @@ function ErpNotiDetail({ id, onBack, onEdit }) {
             {/* 하단 버튼 영역 */}
             <div className="notice-detail-buttons">
                 <button className="notice-button" onClick={onBack}>목록으로</button>
-                <button className="notice-button" onClick={() => onEdit(id)}>수정</button>
+                {notice.empId === currentEmpId && (
+                    <button className="notice-button" onClick={() => onEdit(id)}>수정</button>
+                )}
+
             </div>
         </div>
     );

--- a/front-react/src/pages/erp/Home/ErpNotices.jsx
+++ b/front-react/src/pages/erp/Home/ErpNotices.jsx
@@ -3,115 +3,113 @@ import './erpNotices.css';
 import axiosInstance from '../../login/social/utils/axiosInstance';
 
 function ErpNotices({ onViewDetail, onEdit }) {
-    // 상태 정의
-    const [notices, setNotices] = useState([]);              // 공지 목록 데이터
-    const [searchTerm, setSearchTerm] = useState('');        // 검색어
-    const [searchType, setSearchType] = useState('title');   // 검색 유형 (제목/내용 등)
-    const [categories, setCategories] = useState([]);        // 전체 카테고리 목록
-    const [selectedType, setSelectedType] = useState('');    // 선택된 카테고리
-    const [statusFilter, setStatusFilter] = useState('');    // 상태 필터 (active/inactive)
+    const currentEmpId = localStorage.getItem('user_uuid');
 
-    // 정렬 조건을 백엔드로 넘겨주는 핵심 키
-    const [sortField, setSortField] = useState('');          // 정렬 필드 (empId, 작성일 등)
-    const [sortOrder, setSortOrder] = useState('asc');       // 정렬 방향
+    const [notices, setNotices] = useState([]);
+    const [searchTerm, setSearchTerm] = useState('');
+    const [searchType, setSearchType] = useState('title');
+    const [categories, setCategories] = useState([]);
+    const [selectedType, setSelectedType] = useState('');
+    const [statusFilter, setStatusFilter] = useState('');
+    const [showMyPostsOnly, setShowMyPostsOnly] = useState(false);
 
-    // 페이지
-    const [currentPage, setCurrentPage] = useState(0);       // 현재 페이지
-    const [totalPages, setTotalPages] = useState(0);         // 전체 페이지 수
-    const pageSize = 10;        // 페이지당 표시할 항목 수
+    const [sortField, setSortField] = useState('erpNotiCreatedAt');
+    const [sortOrder, setSortOrder] = useState('desc');
 
-    // 검색 및 필터 처리 함수
-    const handleSearch = useCallback(() => {    // 	useCallback( ) : handleSearch() 함수의 메모이제이션. 불필요한 재생성 방지.
+    const [currentPage, setCurrentPage] = useState(0);
+    const [totalPages, setTotalPages] = useState(0);
+    const pageSize = 10;
+
+    const handleSearch = useCallback(() => {
         const params = {
             keyword: searchTerm,
-            searchType: searchType,
+            searchType,
             category: selectedType || undefined,
             status: statusFilter || undefined,
+            empId: showMyPostsOnly ? currentEmpId : undefined,
             page: currentPage,
             size: pageSize,
-            sort: sortField ? `${sortField},${sortOrder}` : undefined,
+            sort: sortField ? `${sortField},${sortOrder}` : 'erpNotiCreatedAt,desc',
         };
 
         axiosInstance.get('/api/notices/search', { params })
             .then(response => {
                 const data = response.data;
-                setNotices(data.content);       // 공지 목록 저장
-                setTotalPages(data.totalPages); // 전체 페이지 수 저장
+                setNotices(data.content);
+                setTotalPages(data.totalPages);
 
-                // 공지에서 카테고리 목록 추출 (중복 제거)
-                const uniqueTypes = [...new Set(data.content.map(notice => notice.erpNotiType))];
+                const uniqueTypes = [...new Set(data.content.map(n => n.erpNotiType))];
                 setCategories(uniqueTypes);
             })
-            .catch(error => {
-                console.error('Error fetching notices:', error);
-            });
-    }, [searchTerm, searchType, selectedType, statusFilter, sortField, sortOrder, currentPage]);
+            .catch(error => console.error('공지 불러오기 실패:', error));
+    }, [searchTerm, searchType, selectedType, statusFilter, sortField, sortOrder, currentPage, showMyPostsOnly]);
 
-    // 최초 렌더링 또는 의존성 변경 시 검색 수행
     useEffect(() => {
         handleSearch();
     }, [handleSearch]);
 
-    // 초기화 버튼 클릭 시
     const handleReset = () => {
         setSearchTerm('');
         setSearchType('title');
         setSelectedType('');
         setStatusFilter('');
-        setSortField('');
-        setSortOrder('asc');
+        setSortField('erpNotiCreatedAt');
+        setSortOrder('desc');
         setCurrentPage(0);
+        setShowMyPostsOnly(false);
     };
 
-     // 날짜 포맷 변환 함수
-    const formatDate = (dateTimeString) => {
-        if (!dateTimeString) return '';
-        const date = new Date(dateTimeString);
+    const formatDate = (datetime) => {
+        if (!datetime) return '';
+        const date = new Date(datetime);
         return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
     };
 
-    // 삭제 처리 함수
     const handleDelete = (id) => {
         if (window.confirm('정말 삭제하시겠습니까?')) {
             axiosInstance.delete(`/api/notices/delete/${id}`)
-                .then(() => {
-                    handleSearch();     // 삭제 후 목록 갱신
-                })
-                .catch(error => {
-                    console.error('Error deleting notice:', error);
-                });
+                .then(() => handleSearch())
+                .catch(error => console.error('삭제 실패:', error));
         }
     };
 
-    // 정렬 클릭 시 정렬 상태 변경
     const toggleSort = (field) => {
-        if (sortField === field) {
-            setSortOrder(prev => (prev === 'asc' ? 'desc' : 'asc'));
-        } else {
-            setSortField(field);
-            setSortOrder('asc');
-        }
+        setSortOrder(sortField === field ? (sortOrder === 'asc' ? 'desc' : 'asc') : 'asc');
+        setSortField(field);
         setCurrentPage(0);
     };
 
-    // 정렬 화살표 표시
     const renderSortArrow = (field) => {
         if (sortField !== field) return '▲▼';
         return sortOrder === 'asc' ? '▲' : '▼';
     };
 
-    // 페이지 변경 처리
     const handlePageChange = (page) => {
         if (page >= 0 && page < totalPages) {
             setCurrentPage(page);
         }
     };
 
+    // ✅ 상태만 변경
+    const handleToggleMyPostsOnly = () => {
+        setShowMyPostsOnly(prev => !prev);
+        setCurrentPage(0); // 페이지도 초기화
+    };
+
+    // ✅ 검색 useEffect 업데이트
+    useEffect(() => {
+        handleSearch();
+    }, [
+        handleSearch,
+        showMyPostsOnly, // 🔑 추가
+        currentPage // 🔑 추가 (이미 있을 수도 있음)
+    ]);
+
+
     return (
         <div className="notice-list-container">
             <h3>공지사항 목록</h3>
 
-            {/* 검색 바 영역 */}
             <div className="search-bar">
                 <select value={searchType} onChange={(e) => setSearchType(e.target.value)}>
                     <option value="title">제목</option>
@@ -123,13 +121,15 @@ function ErpNotices({ onViewDetail, onEdit }) {
                     placeholder="검색어를 입력하세요"
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    onKeyDown={(e) => e.key === 'Enter' && handleSearch()}      // 엔터 키 입력 시
+                    onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
                 />
                 <button onClick={handleSearch}>검색</button>
                 <button className="reset-button" onClick={handleReset}>초기화</button>
+                <button className="toggle-button" onClick={handleToggleMyPostsOnly}>
+                    {showMyPostsOnly ? '전체 공지 보기' : '내 게시물만 보기'}
+                </button>
             </div>
 
-            {/* 공지사항 목록 테이블 */}
             <table>
                 <thead>
                     <tr>
@@ -142,7 +142,6 @@ function ErpNotices({ onViewDetail, onEdit }) {
                             작성일 {renderSortArrow('erpNotiCreatedAt')}
                         </th>
                         <th>
-                            {/* 카테고리(유형) 필터 */}
                             <select className="noti-select" value={selectedType} onChange={(e) => setSelectedType(e.target.value)}>
                                 <option value="">전체 유형</option>
                                 {categories.map(category => (
@@ -151,7 +150,6 @@ function ErpNotices({ onViewDetail, onEdit }) {
                             </select>
                         </th>
                         <th>
-                            {/* 상태 필터 */}
                             <select className="noti-select" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)}>
                                 <option value="">전체</option>
                                 <option value="active">활성</option>
@@ -169,8 +167,8 @@ function ErpNotices({ onViewDetail, onEdit }) {
                                 <span className="notice-link" onClick={() => onViewDetail(notice.erpNotiId)}>
                                     {notice.erpNotiTitle}
                                 </span>
-                                </td>
-                                <td className="ellipsis-cell" title={notice.erpNotiContent}>    {/* ellipsis-cell : 너무 긴 내용은 말줄임 처리 */}
+                            </td>
+                            <td className="ellipsis-cell" title={notice.erpNotiContent}>
                                 <span className="notice-link" onClick={() => onViewDetail(notice.erpNotiId)}>
                                     {notice.erpNotiContent}
                                 </span>
@@ -179,25 +177,32 @@ function ErpNotices({ onViewDetail, onEdit }) {
                             <td>{formatDate(notice.erpNotiCreatedAt)}</td>
                             <td>{notice.erpNotiType}</td>
                             <td>{notice.erpNotiStatus}</td>
-                            <td className="button-cell">
-                                <button className="noti-edit-button" onClick={() => onEdit(notice.erpNotiId)}>수정</button>
+                            <td>
+                                {notice.empId === currentEmpId ? (
+                                    <button className="noti-edit-button" onClick={() => onEdit(notice.erpNotiId)}>수정</button>
+                                ) : (
+                                    <button className="noti-edit-button" disabled>수정</button>
+                                )}
                             </td>
-                            <td className="button-cell">
-                                <button className="noti-delete-button" onClick={() => handleDelete(notice.erpNotiId)}>삭제</button>
+                            <td>
+                                {notice.empId === currentEmpId ? (
+                                    <button className="noti-delete-button" onClick={() => handleDelete(notice.erpNotiId)}>삭제</button>
+                                ) : (
+                                    <button className="noti-delete-button" disabled>삭제</button>
+                                )}
                             </td>
                         </tr>
                     ))}
                 </tbody>
             </table>
 
-            {/* 페이징 영역 */}
             <div className="pagination">
                 <button onClick={() => handlePageChange(currentPage - 1)} disabled={currentPage === 0}>이전</button>
-                {Array.from({ length: totalPages }, (_, idx) => (   // 페이지 수 만큼 숫자 버튼 만들기 위한 반복 배열 생성
+                {Array.from({ length: totalPages }, (_, idx) => (
                     <button
-                        key={idx}   // 0부터 시작하는 페이지 인덱스
+                        key={idx}
                         onClick={() => handlePageChange(idx)}
-                        className={idx === currentPage ? 'active' : ''}     // active 클래스 추가(색상 강조)
+                        className={idx === currentPage ? 'active' : ''}
                     >
                         {idx + 1}
                     </button>

--- a/front-react/src/pages/erp/Home/erpNotices.css
+++ b/front-react/src/pages/erp/Home/erpNotices.css
@@ -1,167 +1,180 @@
-/* =======================
-   공지사항 목록 전체 레이아웃
-   ======================= */
-   .notice-list-container {
-    padding: 20px;
-    max-width: 1000px;
-    margin: 0 auto;
-    overflow-x: auto; /* 화면이 작을 때 가로 스크롤 허용 */
-  }
-  
-  /* =======================
-     검색 바 스타일
-     ======================= */
-  .search-bar {
-    margin: 30px 0 20px;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-  }
-  
-  .search-bar select,
-  .search-bar input,
-  .search-bar button {
-    padding: 8px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-  }
+/* =========================
+   공지사항 레이아웃
+========================= */
+.notice-list-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 24px;
+  overflow-x: auto;
+}
 
-  .noti-select {
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    padding: 3px;
-  }
-  
-  /* =======================
-     테이블 스타일
-     ======================= */
-  table {
-    width: 100%;
-    min-width: 800px; /* ✅ 표 자체 최소 너비 */
-    table-layout: fixed;
-    border-collapse: collapse;
-  }
-  
-  th, td {
-    border: 1px solid #ddd;
-    padding: 10px;
-  }
-  
-  /* 테이블 헤더 가운데 정렬 */
-  thead th {
-    background-color: #f2f2f2;
-    text-align: center;
-  }
-  
-  /* 테이블 셀 가운데 정렬 (수정/삭제 버튼용) */
-  .button-cell {
-    text-align: center;
-    vertical-align: middle;
-  }
-  
-  /* 테이블 내용 말줄임 처리 */
-  .ellipsis-cell {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 250px;
-  }
-  
-  /* 테이블 줄무늬 효과 */
-  tr:nth-child(even) {
-    background-color: #f9f9f9;
-  }
-  
-  tr:hover {
-    background-color: #f0f0f0;
-  }
-  
-  /* =======================
-     링크 스타일
-     ======================= */
-  .notice-link {
-    color: #007bff;
-    text-decoration: underline;
-    cursor: pointer;
-  }
-  
-  .notice-link:hover {
-    color: #0056b3;
-  }
-  
-  /* =======================
-     버튼 스타일 (검색, 수정, 삭제 등)
-     ======================= */
-  
-  /* 검색창 초기화 버튼 */
-  .reset-button {
-    background-color: #f0ad4e;
-    color: white;
-    padding: 8px 15px;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-  }
-  
-  .reset-button:hover {
-    background-color: #ec971f;
-  }
-  
-  /* 수정 버튼 */
-  .noti-edit-button {
-    background-color: #0275d8;
-    color: white;
-    padding: 5px 10px;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-  }
-  
-  .noti-edit-button:hover {
-    background-color: #025aa5;
-  }
-  
-  /* 삭제 버튼 */
-  .noti-delete-button {
-    background-color: #d9534f;
-    color: white;
-    padding: 5px 10px;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-  }
-  
-  .noti-delete-button:hover {
-    background-color: #c9302c;
-  }
-  
-  /* =======================
-     페이징 버튼 영역
-     ======================= */
-  .pagination {
-    margin-top: 20px;
-    display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
-    gap: 8px;
-  }
-  
-  .pagination button {
-    padding: 5px 10px;
-    border: 1px solid #ccc;
-    background-color: white;
-    border-radius: 4px;
-    cursor: pointer;
-  }
-  
-  .pagination button.active {
-    font-weight: bold;
-    background-color: #007bff;
-    color: white;
-  }
-  
-  .pagination button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-  
+/* =========================
+   검색 영역
+========================= */
+.search-bar {
+  margin: 24px 0 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.search-bar select,
+.search-bar input,
+.search-bar button {
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.noti-select {
+  padding: 6px 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+/* =========================
+   테이블
+========================= */
+table {
+  width: 100%;
+  min-width: 800px;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+thead th {
+  background-color: #f8f8f8;
+  text-align: center;
+  padding: 12px;
+  font-weight: 600;
+  border: 1px solid #ddd;
+  cursor: pointer;
+}
+
+tbody td {
+  border: 1px solid #eee;
+  padding: 10px;
+  vertical-align: middle;
+  text-align: center;
+}
+
+/* 줄무늬 효과 */
+tbody tr:nth-child(even) {
+  background-color: #fafafa;
+}
+
+tbody tr:hover {
+  background-color: #f0f0f0;
+}
+
+/* 내용 셀 말줄임 */
+.ellipsis-cell {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 250px;
+  text-align: left;
+}
+
+/* 링크 스타일 */
+.notice-link {
+  color: #212529;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.notice-link:hover {
+  color: #2c6fdb;
+  text-decoration: underline;
+}
+
+/* =========================
+   버튼 스타일
+========================= */
+button {
+  font-size: 14px;
+}
+
+/* 검색 초기화 */
+.reset-button {
+  background-color: #f0ad4e;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.reset-button:hover {
+  background-color: #ec971f;
+}
+
+/* 내 게시물/전체 보기 토글 버튼 */
+.toggle-button {
+  background-color: #5bc0de;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.toggle-button:hover {
+  background-color: #31b0d5;
+}
+
+/* 수정 버튼 */
+.noti-edit-button {
+  background-color: #0275d8;
+  color: white;
+  border: none;
+  padding: 5px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.noti-edit-button:hover {
+  background-color: #025aa5;
+}
+
+/* 삭제 버튼 */
+.noti-delete-button {
+  background-color: #d9534f;
+  color: white;
+  border: none;
+  padding: 5px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.noti-delete-button:hover {
+  background-color: #c9302c;
+}
+
+/* =========================
+   페이징
+========================= */
+.pagination {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pagination button {
+  padding: 6px 12px;
+  border: 1px solid #ddd;
+  background-color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.pagination button.active {
+  font-weight: bold;
+  background-color: #007bff;
+  color: white;
+}
+
+.pagination button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/front-react/src/pages/erp/MyPage/NotificationList.jsx
+++ b/front-react/src/pages/erp/MyPage/NotificationList.jsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from "react";
+import axiosInstance from "../../login/social/utils/axiosInstance";
+import { useNavigate } from "react-router-dom";
+import { Button, IconButton } from "rsuite";
+import { Trash } from "@rsuite/icons";
+import "./notificationList.css";
+
+function NotificationList() {
+  const [notifications, setNotifications] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const userUuid = localStorage.getItem("user_uuid");
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (userUuid) {
+      fetchNotifications();
+    }
+  }, [userUuid]);
+
+  const fetchNotifications = async () => {
+    try {
+      const res = await axiosInstance.get(`/api/notifications/${userUuid}`);
+      setNotifications(res.data);
+    } catch (err) {
+      console.error("알림 조회 실패:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleMarkAllRead = async () => {
+    const unreadIds = notifications
+      .filter(n => (n.empId !== 'ALL' && !n.isRead) || (n.empId === 'ALL' && !n.readByCurrentUser))
+      .map(n => n.notificationId);
+
+    await Promise.all(
+      unreadIds.map(id =>
+        axiosInstance.post(`/api/notifications/read/${id}/${userUuid}`)
+      )
+    );
+
+    fetchNotifications();
+  };
+
+  const handleDeleteAll = async () => {
+    try {
+      await axiosInstance.delete(`/api/notifications/deleteAll/${userUuid}`);
+      fetchNotifications();
+    } catch (err) {
+      console.error("전체 삭제 실패:", err);
+    }
+  };
+  
+
+  const handleDeleteOne = async (noti) => {
+    if (noti.empId === "ALL") {
+      // 공용 알림은 삭제 기록만 남김
+      await axiosInstance.post(`/api/notifications/dismiss/${noti.notificationId}/${userUuid}`);
+    } else {
+      // 개인 알림은 실제 삭제
+      await axiosInstance.delete(`/api/notifications/delete/${noti.notificationId}/${userUuid}`);
+    }
+    fetchNotifications();
+  };
+  
+
+  const handleClick = async (noti) => {
+    await axiosInstance.post(`/api/notifications/read/${noti.notificationId}/${userUuid}`);
+    
+    if (noti.relatedType === "notice") {
+      navigate(`/erpMain?view=detail&id=${noti.relatedId}`);
+    } else if (noti.relatedType === "schedule") {
+      alert(`📌 일정 제목: ${noti.notificationTitle.replace('[일정] 마감 예정: ', '')}`);
+    }
+  };
+
+  if (loading) return <div>⏳ 불러오는 중...</div>;
+
+  return (
+    <div className="notification-list">
+      <div className="notification-header">
+        <h3>🔔 내 알림 목록</h3>
+        <div>
+          <Button size="sm" onClick={handleMarkAllRead}>모두 읽음</Button>{" "}
+          <Button size="sm" color="red" onClick={handleDeleteAll}>모두 삭제</Button>
+        </div>
+      </div>
+      {notifications.length === 0 ? (
+        <p>알림이 없습니다.</p>
+      ) : (
+        <ul>
+          {notifications.map((noti) => (
+            <li
+              key={noti.notificationId}
+              className={noti.isRead || noti.readByCurrentUser ? "read" : "unread"}
+            >
+              <div className="noti-content" onClick={() => handleClick(noti)}>
+                <strong>{noti.notificationTitle}</strong>
+                <br />
+                <small>{new Date(noti.createdAt).toLocaleString()}</small>
+              </div>
+              <IconButton
+                icon={<Trash />}
+                onClick={() => handleDeleteOne(noti)}
+                appearance="subtle"
+                circle
+                size="sm"
+                style={{ marginLeft: "10px" }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default NotificationList;

--- a/front-react/src/pages/erp/MyPage/notificationList.css
+++ b/front-react/src/pages/erp/MyPage/notificationList.css
@@ -1,0 +1,67 @@
+.notification-list {
+  padding: 30px;
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.notification-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.notification-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.notification-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 18px;
+  border-radius: 8px;
+  border: 1px solid #e6e6e6;
+  margin-bottom: 10px;
+  transition: background-color 0.2s;
+  cursor: pointer;
+}
+
+.notification-list li:hover {
+  background-color: #f5faff;
+}
+
+.notification-list li.unread {
+  background-color: #eaf6ff;
+  font-weight: 600;
+}
+
+.notification-list li.read {
+  background-color: #fafafa;
+  font-weight: 400;
+}
+
+.noti-content {
+  flex: 1;
+}
+
+.noti-content strong {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 15px;
+  color: #333;
+}
+
+.noti-content small {
+  color: #888;
+  font-size: 12px;
+}
+
+.rs-btn-icon {
+  margin-left: 12px;
+}

--- a/front-react/src/pages/erp/PAY_Team/SubscriptionManager.jsx
+++ b/front-react/src/pages/erp/PAY_Team/SubscriptionManager.jsx
@@ -42,7 +42,7 @@ function SubscriptionManager() {
   const handleRefund = async (impUid) => {
     try {
       const empId = localStorage.getItem('user_uuid');
-      await axiosInstance.post(`/api/purchase/refund/${impUid}`,{
+      await axiosInstance.post(`/api/purchase/refund/${impUid}`, {
         empId
       });
       toaster.push(<Message showIcon type="success">환불 완료</Message>);
@@ -99,6 +99,11 @@ function SubscriptionManager() {
               <Column flexGrow={1} align="center">
                 <HeaderCell>회원 이름</HeaderCell>
                 <Cell dataKey="name" />
+              </Column>
+
+              <Column flexGrow={1} align="center">
+                <HeaderCell>닉네임</HeaderCell>
+                <Cell dataKey="nickname" />
               </Column>
 
               <Column flexGrow={1} align="center">

--- a/src/main/java/com/boot/tico/TicoTeamApplication.java
+++ b/src/main/java/com/boot/tico/TicoTeamApplication.java
@@ -3,9 +3,11 @@ package com.boot.tico;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync  // 비동기 처리를 활성화합니다.
+@EnableScheduling // 스케줄링 처리 활성화
 public class TicoTeamApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/boot/tico/erp/controller/ErpNotiController.java
+++ b/src/main/java/com/boot/tico/erp/controller/ErpNotiController.java
@@ -49,8 +49,9 @@ public class ErpNotiController {
             @RequestParam(required = false) String searchType,
             @RequestParam(required = false) String category,
             @RequestParam(required = false) String status,
+            @RequestParam(required = false) String empId,
             Pageable pageable) {
-        return notiService.searchNoticesWithPaging(keyword, searchType, category, status, pageable);
+        return notiService.searchNoticesWithPaging(keyword, searchType, category, status, empId, pageable);
     }
 
     /**

--- a/src/main/java/com/boot/tico/erp/controller/NotificationController.java
+++ b/src/main/java/com/boot/tico/erp/controller/NotificationController.java
@@ -1,0 +1,75 @@
+package com.boot.tico.erp.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.boot.tico.erp.dto.Notification;
+import com.boot.tico.erp.service.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService service;
+
+    //(1) 내 전체 알림 조회
+    @GetMapping("/{empId}")
+    public ResponseEntity<List<Notification>> getAllNotifications(@PathVariable String empId) {
+        List<Notification> notifications = service.getAllNotifications(empId);
+        return ResponseEntity.ok(notifications);
+    }
+
+    // (2) 내 읽지 않은 알림만 조회
+    @GetMapping("/unread/{empId}")
+    public ResponseEntity<List<Notification>> getUnreadNotifications(@PathVariable String empId) {
+        List<Notification> notifications = service.getUnreadNotifications(empId);
+        return ResponseEntity.ok(notifications);
+    }
+
+    // (3) 특정 알림 읽음 처리
+    @PostMapping("/read/{notificationId}/{empId}")
+    public ResponseEntity<String> markNotificationAsRead(@PathVariable Long notificationId, @PathVariable String empId) {
+    	System.out.println("📥 읽음 요청 도착 - 알림 ID: " + notificationId + ", 사원 ID: " + empId);
+    	
+    	boolean success = service.markAsRead(notificationId, empId);
+    	return ResponseEntity.ok("알림 읽음 처리 완료"); // ✔️ 무조건 200 반환
+    }
+
+    // (4) 특정 알림 삭제
+    @DeleteMapping("/delete/{notificationId}/{empId}")
+    public ResponseEntity<String> deleteNotification(@PathVariable Long notificationId, @PathVariable String empId) {
+    	boolean success = service.deleteNotification(notificationId, empId);
+        if (success) {
+            return ResponseEntity.ok("알림 삭제 완료");
+        } else {
+            return ResponseEntity.badRequest().body("알림 삭제 실패");
+        }
+    }
+    
+    // (5) 전체 알림 삭제 (개인 + 공용 삭제 이력 기록)
+    @DeleteMapping("/deleteAll/{empId}")
+    public ResponseEntity<String> deleteAllNotifications(@PathVariable String empId) {
+        service.deleteAllNotifications(empId);
+        return ResponseEntity.ok("전체 알림 삭제 완료");
+    }
+    
+    // 공용 알림 삭제(안보이게)
+    @PostMapping("/dismiss/{notificationId}/{empId}")
+    public ResponseEntity<String> dismissGlobalNotification(@PathVariable Long notificationId, @PathVariable String empId) {
+        service.dismissGlobalNotification(notificationId, empId);
+        return ResponseEntity.ok("공용 알림 숨김 처리 완료");
+    }
+    
+    
+
+}

--- a/src/main/java/com/boot/tico/erp/dto/Notification.java
+++ b/src/main/java/com/boot/tico/erp/dto/Notification.java
@@ -1,0 +1,58 @@
+package com.boot.tico.erp.dto;
+
+import java.sql.Timestamp;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "erp_notifications")
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id", nullable = false)
+    private Long notificationId;
+
+    // 개인 알림 전용
+    @Column(name = "emp_id", nullable = false)
+    private String empId;       // 알림 받을 사람 / "ALL" or 개별 ID (예: admin001)
+
+    @Column(name = "notification_title", nullable = false)
+    private String notificationTitle;  // 알림 제목
+
+    @Column(name = "notification_message", columnDefinition = "TEXT")
+    private String notificationMessage; // 알림 본문 (선택)
+
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead = false;     // 읽음 여부
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Timestamp createdAt = new Timestamp(System.currentTimeMillis());
+
+    @Column(name = "related_type")
+    private String relatedType;     // 'notice' or 'schedule'
+
+    @Column(name = "related_id")
+    private Long relatedId;         // 공지 ID나 일정 ID
+
+    @Column(name = "link_url")
+    private String linkUrl;         // 클릭 시 이동할 링크
+    
+    // @Transient :  JPA가 이 필드를 DB 컬럼으로 간주하지 않게 함.
+    @Transient
+    private Boolean readByCurrentUser;
+    
+}

--- a/src/main/java/com/boot/tico/erp/dto/NotificationDismissed.java
+++ b/src/main/java/com/boot/tico/erp/dto/NotificationDismissed.java
@@ -1,0 +1,43 @@
+package com.boot.tico.erp.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor	// 모든 필드를 포함한 생성자를 생성하기 때문에 / new NotificationDismissed(notificationId, empId) 이런 식으로 두 개의 파라미터만 주는 생성자는 존재하지 않게 된다.
+@Entity
+@IdClass(NotificationDismissedId.class)
+@Table(name = "notification_dismissed")
+public class NotificationDismissed implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+	
+    @Id
+    @Column(name = "notification_id")
+    private Long notificationId;
+
+    @Id
+    @Column(name = "emp_id")
+    private String empId;
+
+    @Column(name = "dismissed_at")
+    private LocalDateTime dismissedAt = LocalDateTime.now();
+    
+    // 두 파라미터 생성자 추가
+    public NotificationDismissed(Long notificationId, String empId) {
+        this.notificationId = notificationId;
+        this.empId = empId;
+        this.dismissedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/boot/tico/erp/dto/NotificationDismissedId.java
+++ b/src/main/java/com/boot/tico/erp/dto/NotificationDismissedId.java
@@ -1,0 +1,21 @@
+package com.boot.tico.erp.dto;
+
+import java.io.Serializable;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * 복합키 식별자 클래스
+ * - 반드시 Serializable 구현
+ * - equals() & hashCode() 필수
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class NotificationDismissedId implements Serializable {
+	
+    private Long notificationId;
+    private String empId;
+}

--- a/src/main/java/com/boot/tico/erp/dto/NotificationRead.java
+++ b/src/main/java/com/boot/tico/erp/dto/NotificationRead.java
@@ -1,0 +1,36 @@
+package com.boot.tico.erp.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+//1. 엔티티 - NotificationRead.java
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@IdClass(NotificationReadId.class)
+@Table(name = "notification_read")
+public class NotificationRead {
+
+    @Id
+    @Column(name = "notification_id")
+    private Long notificationId;
+
+    @Id
+    @Column(name = "emp_id")
+    private String empId;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt = LocalDateTime.now();
+}

--- a/src/main/java/com/boot/tico/erp/dto/NotificationReadId.java
+++ b/src/main/java/com/boot/tico/erp/dto/NotificationReadId.java
@@ -1,0 +1,21 @@
+package com.boot.tico.erp.dto;
+
+import java.io.Serializable;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * 복합키 식별자 클래스
+ * - 반드시 Serializable 구현
+ * - equals() & hashCode() 필수
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class NotificationReadId implements Serializable {
+
+    private Long notificationId;
+    private String empId;
+}

--- a/src/main/java/com/boot/tico/erp/repo/EmpRepository.java
+++ b/src/main/java/com/boot/tico/erp/repo/EmpRepository.java
@@ -29,5 +29,8 @@ public interface EmpRepository extends JpaRepository<EmpDTO, String> {
     // empId의 max값 조회
     @Query("SELECT MAX(e.empId) FROM EmpDTO e")
     String findMaxEmpId();
+    
+    // 해당 empId가 employees 테이블에 존재하는지 확인하는 메서드
+    boolean existsByEmpId(String empId);
 }
 

--- a/src/main/java/com/boot/tico/erp/repo/ErpNotiRepository.java
+++ b/src/main/java/com/boot/tico/erp/repo/ErpNotiRepository.java
@@ -26,12 +26,14 @@ public interface ErpNotiRepository extends JpaRepository<ErpNotiDTO, Long> {
 	        "(:searchType = 'content' AND e.erpNotiContent LIKE %:keyword%) OR " +
 	        "(:searchType = 'titleAndContent' AND (e.erpNotiTitle LIKE %:keyword% OR e.erpNotiContent LIKE %:keyword%))) " +
 	        "AND (:category IS NULL OR e.erpNotiType = :category) " +
-	        "AND (:status IS NULL OR e.erpNotiStatus = :status)")
+	        "AND (:status IS NULL OR e.erpNotiStatus = :status)" +
+			"AND (:empId IS NULL OR e.empId = :empId)") 
 	Page<ErpNotiDTO> findByKeywordPaging(
 	        @Param("keyword") String keyword,
 	        @Param("searchType") String searchType,
 	        @Param("category") String category,
 	        @Param("status") String status,
+	        @Param("empId") String empId,
 	        Pageable pageable);	// 검색 조건에 맞는 공지사항을 페이징 처리하여 반환. 페이징은 Pageable 객체로 처리. 반환 타입은 Page<ErpNotiDTO>
 
 	
@@ -40,5 +42,7 @@ public interface ErpNotiRepository extends JpaRepository<ErpNotiDTO, Long> {
     
     // 최근 공지사항 5개
     List<ErpNotiDTO> findAllByOrderByErpNotiCreatedAtDesc(Pageable pageable);	// findAllBy: ErpNotiDTO 엔티티에 대한 모든 데이터 조회하는 메서드
-        
+    
+    // 내일 만료돌 공지사항 조회
+    List<ErpNotiDTO> findByErpNotiExpiredAt(LocalDate expiredAt);
 }

--- a/src/main/java/com/boot/tico/erp/repo/ErpScheduleRepository.java
+++ b/src/main/java/com/boot/tico/erp/repo/ErpScheduleRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.boot.tico.erp.dto.ErpScheduleDTO;
 
 /**
- * 🗂️ 일정 관련 DB 접근을 담당하는 Repository
+ * 일정 관련 DB 접근을 담당하는 Repository
  * - JpaRepository 를 상속하여 기본 CRUD 기능 자동 제공
  * - 메서드 이름 기반 쿼리로 커스텀 조회 구현
  */
@@ -22,4 +22,7 @@ public interface ErpScheduleRepository extends JpaRepository<ErpScheduleDTO, Lon
 
     // 특정 시간 이후의 일정 조회
     List<ErpScheduleDTO> findByEmpIdAndErpScheduleStartAfter(String empId, LocalDateTime time);
+    
+    // 내일 만료될 일정
+    List<ErpScheduleDTO> findByErpScheduleEndBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/boot/tico/erp/repo/NotificationDismissedRepo.java
+++ b/src/main/java/com/boot/tico/erp/repo/NotificationDismissedRepo.java
@@ -1,0 +1,10 @@
+package com.boot.tico.erp.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.boot.tico.erp.dto.NotificationDismissed;
+import com.boot.tico.erp.dto.NotificationDismissedId;
+
+public interface NotificationDismissedRepo extends JpaRepository<NotificationDismissed, NotificationDismissedId> {
+    boolean existsByNotificationIdAndEmpId(Long notificationId, String empId);
+}

--- a/src/main/java/com/boot/tico/erp/repo/NotificationReadRepo.java
+++ b/src/main/java/com/boot/tico/erp/repo/NotificationReadRepo.java
@@ -1,0 +1,13 @@
+package com.boot.tico.erp.repo;
+
+import com.boot.tico.erp.dto.NotificationRead;
+import com.boot.tico.erp.dto.NotificationReadId;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationReadRepo extends JpaRepository<NotificationRead, NotificationReadId> {
+    boolean existsByNotificationIdAndEmpId(Long notificationId, String empId);
+    Optional<NotificationRead> findByNotificationIdAndEmpId(Long notificationId, String empId);
+}

--- a/src/main/java/com/boot/tico/erp/repo/NotificationRepo.java
+++ b/src/main/java/com/boot/tico/erp/repo/NotificationRepo.java
@@ -1,0 +1,24 @@
+package com.boot.tico.erp.repo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.boot.tico.erp.dto.ErpScheduleDTO;
+import com.boot.tico.erp.dto.Notification;
+
+@Repository
+public interface NotificationRepo extends JpaRepository<Notification, Long>{
+	
+	// 특정 사용자의 안 읽은 알림
+    List<Notification> findByEmpIdAndIsReadFalseOrderByCreatedAtDesc(String empId);
+
+    // 특정 사용자의 전체 알림
+    List<Notification> findByEmpIdOrderByCreatedAtDesc(String empId);
+    
+    // 중복알림 체크용
+    boolean existsByRelatedTypeAndRelatedIdAndEmpId(String relatedType, Long relatedId, String empId);
+
+}

--- a/src/main/java/com/boot/tico/erp/service/ErpNotiService.java
+++ b/src/main/java/com/boot/tico/erp/service/ErpNotiService.java
@@ -20,14 +20,19 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.boot.tico.erp.dto.EmpDTO;
 import com.boot.tico.erp.dto.ErpNotiDTO;
+import com.boot.tico.erp.dto.Notification;
 import com.boot.tico.erp.repo.EmpRepository;
 import com.boot.tico.erp.repo.ErpNotiRepository;
+import com.boot.tico.erp.repo.NotificationRepo;
 
 @Service
 public class ErpNotiService {
 
     @Autowired
     private ErpNotiRepository notiRepo;
+    
+    @Autowired
+    private NotificationRepo notificationRepo;
     
     @Autowired 
     private EmpRepository empRepo;
@@ -42,16 +47,14 @@ public class ErpNotiService {
     
     // 공지사항 목록 검색 + 필터링 + 페이징 처리
     // Page<T> 타입으로 리턴. 페이지 처리된 결과를 포함한 객체. (현재 페이지 데이터 목록 getContent(), 전체 페이지 수 getTotalPages(), 전체 데이터 개수 getTotalElements(), 현재 페이지 번호 getNumber()) 
-    public Page<ErpNotiDTO> searchNoticesWithPaging(String keyword, String searchType, String category, String status, Pageable pageable) {
-        return notiRepo.findByKeywordPaging(keyword, searchType, category, status, pageable);
+    public Page<ErpNotiDTO> searchNoticesWithPaging(String keyword, String searchType, String category, String status, String empId, Pageable pageable) {
+        return notiRepo.findByKeywordPaging(keyword, searchType, category, status, empId, pageable);
     }
 
     // 단건 조회
     public ErpNotiDTO getComNotiById(Long id) {
         return notiRepo.findById(id).orElse(null);
     }
-    
-    
 
     // 공지 등록(파일 포함)
     public ResponseEntity<?> createNotice(ErpNotiDTO notice, MultipartFile file) {
@@ -70,7 +73,37 @@ public class ErpNotiService {
             notice.setErpNotiCreatedAt(Timestamp.valueOf(LocalDateTime.now()));
             updateNoticeStatus(notice);
 
+            // 공지사항 저장
             notiRepo.save(notice);
+            
+            // 내일 날짜 계산. 알림 자동 생성 로직 추가 (내일 마감 공지. 모든 직원이 조회할 수 있게)
+            LocalDate tomorrow = LocalDate.now().plusDays(1);
+            
+        	// 내일 마감인 공지일 때만 알림 생성
+            if (notice.getErpNotiExpiredAt() != null &&
+                notice.getErpNotiExpiredAt().toLocalDate().isEqual(tomorrow)) {
+            	
+            	// 실수 방지 코드
+                String empId = "ALL";
+                if (!"ALL".equals(empId) && !empRepo.existsByEmpId(empId)) {
+                    throw new IllegalArgumentException("알림 대상자가 존재하지 않습니다: " + empId);
+                }
+                
+            	// 중복 알림 방지: 이미 생성된 알림이 있는지 확인
+                boolean exists = notificationRepo.existsByRelatedTypeAndRelatedIdAndEmpId("notice", notice.getErpNotiId(), "ALL");
+                
+                if (!exists) {
+                Notification notification = new Notification();
+                notification.setEmpId("ALL");  // 관리자 전체에게 보이는 알림
+                notification.setNotificationTitle("[공지] 만료 예정: " + notice.getErpNotiTitle());
+                notification.setNotificationMessage("등록된 공지사항이 내일 만료됩니다.");
+                notification.setRelatedType("notice");
+                notification.setRelatedId(notice.getErpNotiId());
+                notification.setLinkUrl("/noticeDetail/" + notice.getErpNotiId());
+
+                notificationRepo.save(notification);
+            }
+           }
             return ResponseEntity.ok("공지사항 등록 성공");
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/boot/tico/erp/service/ErpScheduleService.java
+++ b/src/main/java/com/boot/tico/erp/service/ErpScheduleService.java
@@ -1,11 +1,18 @@
 package com.boot.tico.erp.service;
 
 import com.boot.tico.erp.dto.ErpScheduleDTO;
+import com.boot.tico.erp.dto.Notification;
+import com.boot.tico.erp.repo.EmpRepository;
 import com.boot.tico.erp.repo.ErpScheduleRepository;
+import com.boot.tico.erp.repo.NotificationRepo;
+
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -14,6 +21,8 @@ import java.util.List;
 public class ErpScheduleService {
 
     private final ErpScheduleRepository repo;
+    private final NotificationRepo notificationRepo;
+    private final EmpRepository empRepo;
 
     /**
      * 사원별 전체 일정 조회
@@ -36,6 +45,43 @@ public class ErpScheduleService {
         schedule.setErpScheduleCreateAt(now);       // 생성일 자동 세팅
         schedule.setErpScheduleUpdatedAt(now);      // 수정일도 초기값 세팅
         return repo.save(schedule);
+    }
+    
+    /**
+     * 매일 자정, 내일 마감 일정 관리자에게 알림 전송
+     */
+    @Scheduled(cron = "0 0 0 * * *") // 매일 00:00 실행 "0 0 0 * * *"
+    public void notifyTomorrowDeadlines() {
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+        LocalDateTime start = tomorrow.atStartOfDay();
+        LocalDateTime end = tomorrow.plusDays(1).atStartOfDay();
+
+        List<ErpScheduleDTO> expiringSchedules = repo.findByErpScheduleEndBetween(start, end);
+
+        for (ErpScheduleDTO schedule : expiringSchedules) {
+            String empId = schedule.getEmpId();
+            
+            // 실수 방지 코드
+            if (!"ALL".equals(empId) && !empRepo.existsByEmpId(empId)) {
+                System.out.println("❌ 알림 대상자가 존재하지 않습니다: " + empId);
+                continue;
+            }
+
+            boolean exists = notificationRepo.existsByRelatedTypeAndRelatedIdAndEmpId("schedule", schedule.getErpScheduleId(), empId);
+            if (!exists) {
+                Notification noti = new Notification();
+                noti.setEmpId(empId);  // 관리자 개인 알림
+                noti.setNotificationTitle("[일정] 마감 예정: " + schedule.getErpScheduleTitle());
+                noti.setNotificationMessage("등록한 일정이 내일 종료됩니다.");
+                noti.setRelatedType("schedule");
+                noti.setRelatedId(schedule.getErpScheduleId());
+                noti.setLinkUrl("/scheduleDetail/" + schedule.getErpScheduleId());
+
+                notificationRepo.save(noti);
+            }
+        }
+
+        System.out.println("일정 마감 알림 생성 완료 (" + expiringSchedules.size() + "건)");
     }
 
     /**

--- a/src/main/java/com/boot/tico/erp/service/NotificationService.java
+++ b/src/main/java/com/boot/tico/erp/service/NotificationService.java
@@ -1,0 +1,194 @@
+package com.boot.tico.erp.service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.boot.tico.erp.dto.ErpNotiDTO;
+import com.boot.tico.erp.dto.ErpScheduleDTO;
+import com.boot.tico.erp.dto.Notification;
+import com.boot.tico.erp.dto.NotificationDismissed;
+import com.boot.tico.erp.dto.NotificationRead;
+import com.boot.tico.erp.repo.ErpNotiRepository;
+import com.boot.tico.erp.repo.ErpScheduleRepository;
+import com.boot.tico.erp.repo.NotificationDismissedRepo;
+import com.boot.tico.erp.repo.NotificationReadRepo;
+import com.boot.tico.erp.repo.NotificationRepo;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    @Autowired
+    private NotificationRepo notificationRepo;
+    
+    @Autowired
+    private ErpNotiRepository erpNotiRepo;
+    
+    @Autowired
+    private ErpScheduleRepository erpScheduleRepo;
+    
+    @Autowired
+    private NotificationReadRepo readRepo;
+    
+    @Autowired
+    private NotificationDismissedRepo dismissedRepo;
+
+    // (1) 내 전체 알림 조회
+    public List<Notification> getAllNotifications(String empId) {
+    	List<Notification> personal = notificationRepo.findByEmpIdOrderByCreatedAtDesc(empId);
+        List<Notification> global = notificationRepo.findByEmpIdOrderByCreatedAtDesc("ALL");
+        
+        // 💡 공용 알림 중에서, 삭제 안 된 것만 필터링
+        global = global.stream()
+            .filter(noti -> !dismissedRepo.existsByNotificationIdAndEmpId(noti.getNotificationId(), empId))
+            .collect(Collectors.toList());
+        
+        List<Notification> all = new ArrayList<>();
+        all.addAll(personal);
+        all.addAll(global);
+
+        // 최신순 정렬
+        all.sort(Comparator.comparing(Notification::getCreatedAt).reversed());
+        
+        // 각 global 알림에 대해 readByCurrentUser 필드 주입
+        all.forEach(noti -> {
+            if ("ALL".equals(noti.getEmpId())) {
+                boolean isRead = readRepo.existsByNotificationIdAndEmpId(noti.getNotificationId(), empId);
+                noti.setReadByCurrentUser(isRead);  // 👉 커스텀 필드
+            }
+        });
+        return all;
+    }
+
+    // (2) 내 안 읽은 알림 조회
+    public List<Notification> getUnreadNotifications(String empId) {
+    	List<Notification> personal = notificationRepo.findByEmpIdAndIsReadFalseOrderByCreatedAtDesc(empId);
+        List<Notification> global = notificationRepo.findByEmpIdAndIsReadFalseOrderByCreatedAtDesc("ALL");
+
+        List<Notification> unread = new ArrayList<>();
+        unread.addAll(personal);
+        unread.addAll(global);
+
+        unread.sort(Comparator.comparing(Notification::getCreatedAt).reversed());
+
+        return unread;
+    }
+
+    // (3) 알림 읽음 처리
+    public boolean markAsRead(Long notificationId, String empId) {
+    	// 이미 읽은 기록이 있으면 종료
+        if (readRepo.existsByNotificationIdAndEmpId(notificationId, empId)) {
+        	return false;
+        }
+        // 읽음 기록 저장
+        NotificationRead read = new NotificationRead();
+        read.setNotificationId(notificationId);
+        read.setEmpId(empId);
+        readRepo.save(read);
+        
+        // 개인 알림이면 is_read 필드도 업데이트
+        Notification noti = notificationRepo.findById(notificationId).orElse(null);
+        if (noti != null && !noti.getEmpId().equals("ALL")) {
+            noti.setIsRead(true);
+            notificationRepo.save(noti);
+        }
+        return true;
+    }
+    
+ // ✔️ 글로벌 알림 안 읽은 것만 가져오기
+    public List<Notification> getUnreadGlobalNotifications(String empId) {
+        List<Notification> allGlobal = notificationRepo.findByEmpIdOrderByCreatedAtDesc("ALL");
+        return allGlobal.stream()
+            .filter(n -> !readRepo.existsByNotificationIdAndEmpId(n.getNotificationId(), empId))
+            .toList();
+    }
+
+    // (4) 알림 삭제
+    public boolean deleteNotification(Long notificationId, String empId) {
+        Notification noti = notificationRepo.findById(notificationId).orElse(null);
+        if (noti == null) return false;
+
+        if ("ALL".equals(noti.getEmpId())) {
+            // 공용 알림이면 삭제 이력만 남긴다
+            NotificationDismissed dismissed = new NotificationDismissed(notificationId, empId);
+            dismissedRepo.save(dismissed);
+        } else if (empId.equals(noti.getEmpId())) {
+            // 개인 알림이면 실제 삭제
+            notificationRepo.delete(noti);
+        }
+        return true;
+    }
+    
+    // (5) 전체 알림 삭제 (개인 + 공용 삭제 이력 기록)
+    public void deleteAllNotifications(String empId) {
+        List<Notification> all = getAllNotifications(empId);  // 개인 + 공용 필터링 포함된 알림
+
+        for (Notification noti : all) {
+            if ("ALL".equals(noti.getEmpId())) {
+                // 공용 알림은 숨김 처리
+                if (!dismissedRepo.existsByNotificationIdAndEmpId(noti.getNotificationId(), empId)) {
+                    dismissedRepo.save(new NotificationDismissed(noti.getNotificationId(), empId));
+                }
+            } else if (empId.equals(noti.getEmpId())) {
+                // 개인 알림은 직접 삭제
+                notificationRepo.delete(noti);
+            }
+        }
+    }
+
+    // 공용 알림 삭제
+    public void dismissGlobalNotification(Long notificationId, String empId) {
+        NotificationDismissed dismissed = new NotificationDismissed(notificationId, empId);
+        dismissedRepo.save(dismissed);
+    }
+    
+    // (6) 매일 자정마다 공지사항/일정 만료 하루 전 알림 생성
+    @Scheduled(cron = "0 0 0 * * *")
+    public void generateDailyExpiryNotifications() {
+        LocalDate today = LocalDate.now();
+        LocalDate tomorrow = today.plusDays(1);   // 내일 날짜
+
+        // 1. 내일 만료되는 공지사항 조회
+        List<ErpNotiDTO> expiringNotices = erpNotiRepo.findByErpNotiExpiredAt(tomorrow);
+        for (ErpNotiDTO notice : expiringNotices) {
+        	boolean exists = notificationRepo.existsByRelatedTypeAndRelatedIdAndEmpId("notice", notice.getErpNotiId(), "ALL");
+        	if (!exists) {
+            Notification notification = new Notification();
+            notification.setEmpId("ALL");   // 모든 관리자 공용 알림
+            notification.setNotificationTitle("[공지] 만료 예정: " + notice.getErpNotiTitle());
+            notification.setNotificationMessage("등록한 공지사항이 내일 만료됩니다.");
+            notification.setRelatedType("notice");
+            notification.setRelatedId(notice.getErpNotiId());
+            notification.setLinkUrl("/noticeDetail/" + notice.getErpNotiId());  // 이동할 링크
+            notificationRepo.save(notification);
+        }
+       }
+
+        // 2. 내일 만료되는 일정 조회
+        List<ErpScheduleDTO> expiringSchedules = erpScheduleRepo.findByErpScheduleEndBetween(
+            tomorrow.atStartOfDay(),
+            tomorrow.plusDays(1).atStartOfDay()
+        );
+        for (ErpScheduleDTO schedule : expiringSchedules) {
+            Notification notification = new Notification();
+            notification.setEmpId(schedule.getEmpId());
+            notification.setNotificationTitle("[일정] 마감 예정: " + schedule.getErpScheduleTitle());
+            notification.setNotificationMessage("등록한 일정이 내일 종료됩니다.");
+            notification.setRelatedType("schedule");
+            notification.setRelatedId(schedule.getErpScheduleId());
+            notification.setLinkUrl("/scheduleDetail/" + schedule.getErpScheduleId());	// 이동할 링크
+            notificationRepo.save(notification);
+        }
+
+        System.out.println("만료 예정 알림 생성 완료");
+    }
+}

--- a/src/main/java/com/boot/tico/purchase/controller/PurchaseController.java
+++ b/src/main/java/com/boot/tico/purchase/controller/PurchaseController.java
@@ -54,7 +54,7 @@ public class PurchaseController {
                                            @RequestBody PaymentVerifyRequest request) {
         try {
             IamportResponse<Payment> iamportResponse = iamportClient.paymentByImpUid(impUid);
-            log.info("✅ 아임포트 결제 응답: 주문번호={}, 금액={}, 상태={}",
+            log.info("아임포트 결제 응답: 주문번호={}, 금액={}, 상태={}",
                     iamportResponse.getResponse().getMerchantUid(),
                     iamportResponse.getResponse().getAmount(),
                     iamportResponse.getResponse().getStatus());
@@ -133,8 +133,8 @@ public class PurchaseController {
     @PostMapping("/refund/{impUid}")
     public ResponseEntity<?> refundPayment(@PathVariable String impUid, @RequestBody RefundRequest request) {
         try {
-            Purchase refunded = service.refundByImpUid(impUid, request.getEmpId());
-            return ResponseEntity.ok(refunded); // 환불된 정보 반환
+            service.refundByImpUid(impUid, request.getEmpId());
+            return ResponseEntity.ok().build();		// 반환은 아무것도 안 주거나 메시지만
         } catch (Exception e) {
             log.error("❌ 환불 처리 실패: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -142,7 +142,7 @@ public class PurchaseController {
         }
     }
     
- // ✅ 영수증 데이터 조회 (마이페이지 모달용)
+ // 영수증 데이터 조회 (마이페이지 모달용)
     @GetMapping("/receipt-data/{userUuid}")
     public ResponseEntity<?> getReceiptData(@PathVariable String userUuid) {
         try {

--- a/src/main/java/com/boot/tico/purchase/dto/Purchase.java
+++ b/src/main/java/com/boot/tico/purchase/dto/Purchase.java
@@ -4,10 +4,16 @@ import java.time.LocalDateTime;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
+
+import com.boot.tico.login.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,9 +28,27 @@ import lombok.NoArgsConstructor;
 @Table(name="user_subscription")
 public class Purchase {
 	@Id
-    @Column(name = "user_uuid", length = 36)
-    private String userUuid;  // FK: users 테이블
+	@Column(name = "user_uuid", length = 36)
+	private String userUuid; // 그대로 유지 (PK)
 
+	/* Purchase → User 관계는 다대일(ManyToOne) 관계
+	 * : 여러 구독(Purchase)이 하나의 유저(User)에 연결될 수 있다는 의미.
+	 * 
+	 * fetch = FetchType.LAZY는 지연 로딩을 의미
+	 * → 처음엔 user를 로딩하지 않고, p.getUser()가 호출될 때 DB에서 조회됨.
+	 * 
+	 * @JoinColumn(name = "user_uuid", insertable = false, updatable = false)
+	 * userUuid라는 진짜 컬럼 필드가 존재한다. (private String userUuid;)
+	 * 단순 조회의 목적으로 private User user; 선언 
+	 * -> 단순히 연결을 위한 조회용이라, 실제 DB에 값을 insert/update하지 않음.
+	 * 
+	 * @JsonIgnore
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_uuid", insertable = false, updatable = false) // 외래키 연결
+	@JsonIgnore
+	private User user;
+	
     @Column(name = "active", nullable = false)
     private boolean active = false;
 

--- a/src/main/java/com/boot/tico/purchase/dto/SubscriptionResponseDTO.java
+++ b/src/main/java/com/boot/tico/purchase/dto/SubscriptionResponseDTO.java
@@ -21,6 +21,7 @@ public class SubscriptionResponseDTO {
 	private boolean expired;
 	
 	private String name;	// 회원 이름
+	private String nickname; // 회원 닉네임(중복가입 안됨)
 
     private String transactionId;
 }

--- a/src/main/java/com/boot/tico/purchase/repo/PurchaseLogRepo.java
+++ b/src/main/java/com/boot/tico/purchase/repo/PurchaseLogRepo.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.boot.tico.purchase.dto.PurchaseLog;
 
 public interface PurchaseLogRepo extends JpaRepository<PurchaseLog, Long>{
+	
 	List<PurchaseLog> findAllByOrderByCreatedAtDesc();
 	
 	// userUuid + status 기준으로 최근 결제 완료 내역 하나만 찾기

--- a/src/main/java/com/boot/tico/purchase/repo/PurchaseRepo.java
+++ b/src/main/java/com/boot/tico/purchase/repo/PurchaseRepo.java
@@ -1,11 +1,38 @@
 package com.boot.tico.purchase.repo;
 
+import org.apache.ibatis.annotations.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.boot.tico.purchase.dto.Purchase;
 
 @Repository
 public interface PurchaseRepo extends JpaRepository<Purchase, String>{
-
+	/*
+	 * SELECT p FROM Purchase p JOIN FETCH p.user u : Purchase 엔티티를 기준으로 User 엔티티와
+	 * JOIN FETCH where 조건 : :keyword가 null이면 전체 검색./아니면 u.name(유저 이름)이 keyword를
+	 * 포함하는 경우 p.active = true : 활성화된 이용권만 대상.
+	 * 
+	 * countQuery : value 쿼리로는 페이징이 안 되므로, 개수만 세는 별도 쿼리 필요.
+	 * keyword로 이름 필터, Pageable로 페이지 번호/사이즈 받음
+	 */	
+	
+	@Query(value = """
+		    SELECT p FROM Purchase p 
+		    JOIN FETCH p.user u 
+		    WHERE (:keyword IS NULL OR 
+				    LOWER(u.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+				    LOWER(u.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
+		""",
+		countQuery = """
+		    SELECT COUNT(p) FROM Purchase p 
+		    JOIN p.user u 
+		    WHERE (:keyword IS NULL OR 
+				    LOWER(u.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+				    LOWER(u.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
+		""")
+		Page<Purchase> findActiveWithUser(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/boot/tico/purchase/service/PurchaseService.java
+++ b/src/main/java/com/boot/tico/purchase/service/PurchaseService.java
@@ -131,34 +131,31 @@ public class PurchaseService {
     public Page<SubscriptionResponseDTO> getSubscriptionPage(String keyword, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
 
-        // 이름 기준으로 유저 리스트 가져오기
-        Page<User> userPage = userRepo.findByNameContainingIgnoreCase(keyword, pageable);
+        // 🔹 purchase 기준으로 active이고, 유저 이름에 keyword가 포함된 것만 조회
+        Page<Purchase> purchasePage = purchaseRepo.findActiveWithUser(keyword, pageable);
 
-        // purchase가 있는 유저만 DTO로 변환(일부 유저는 Purchase가 없어서 Optional.get()에서 NPE 발생)
-        List<SubscriptionResponseDTO> dtoList = userPage.stream()
-            .map(user -> {
-                return purchaseRepo.findById(user.getUser_uuid()).map(p -> {
-                    LocalDate now = LocalDate.now();
-                    long remainingDays = ChronoUnit.DAYS.between(now, p.getEndDate().toLocalDate());
-                    boolean expired = remainingDays <= 0;
-                    return SubscriptionResponseDTO.builder()
-                            .name(user.getName())
-                            .startDate(p.getStartDate().toLocalDate())
-                            .endDate(p.getEndDate().toLocalDate())
-                            .active(p.isActive())
-                            .subscriptionType(p.getSubscriptionType())
-                            .remainingDays(Math.max(remainingDays, 0))
-                            .expired(expired)
-                            .transactionId(p.getTransactionId())
-                            .build();
-                }).orElse(null); // purchase 없는 유저 제외
-            })
-            .filter(dto -> dto != null)
-            .toList();	// Java 16+ 또는 collect(Collectors.toList())
+        // 🔹 DTO 변환
+        List<SubscriptionResponseDTO> dtoList = purchasePage.stream().map(p -> {
+            User user = p.getUser(); // join fetch 덕분에 N+1 문제 없음
+            LocalDate now = LocalDate.now();
+            long remainingDays = ChronoUnit.DAYS.between(now, p.getEndDate().toLocalDate());
 
-        // ⚠️ 전체 userPage.getTotalElements() → 실제 DTO 리스트 크기만큼으로 수정
-        return new PageImpl<>(dtoList, pageable, dtoList.size());
+            return SubscriptionResponseDTO.builder()
+                    .name(user.getName())
+                    .nickname(user.getNickname())
+                    .startDate(p.getStartDate().toLocalDate())
+                    .endDate(p.getEndDate().toLocalDate())
+                    .active(p.isActive())
+                    .subscriptionType(p.getSubscriptionType())
+                    .remainingDays(Math.max(remainingDays, 0))
+                    .expired(remainingDays <= 0)
+                    .transactionId(p.getTransactionId())
+                    .build();
+        }).toList();
+
+        return new PageImpl<>(dtoList, pageable, purchasePage.getTotalElements());
     }
+
 
     // 결제건 환불 처리 (관리자용)
     public Purchase refundByImpUid(String impUid, String empId) throws IamportResponseException, IOException {


### PR DESCRIPTION
## Motivation 🧐
<!--변경 사항 및 관련 이슈에 대한 설명란 -->
### [modify] ObjectSelectPage.jsx
- 오브젝트 결제 페이지 모달로 연결

### [feat] NotificationDropdown.jsx & css
- header와 연결되는 알림 드롭다운
- 알림 상세페이지와 연결됨

### [modify] PurchasePage.jsx
- 네비게이트 삭제

### [feat] NotificationList.jsx & css
- 알림 리스트 페이지
- 사용자 UUID 기반으로 개인 및 공용 알림 조회
- 개별 알림 클릭 시 읽음 처리 및 관련 페이지로 이동
- [일정] 알림 클릭 시 알림창으로 정보 제공
- 전체 읽음 및 전체 삭제 기능 추가
- 공용 알림은 soft delete (dismiss), 개인 알림은 hard delete 처리
- 로딩 상태 및 알림 유무에 따른 조건부 렌더링 구현

### [modify] Header.jsx
- 관리자만 알림 모양 보이게

### [modify] ErpNotices.jsx
- 로그인 사용자 UUID 기준으로 개인 작성 공지만 필터링하는 기능 구현
- 필터 상태 유지 및 페이지 초기화 처리 추가
- 전체 공지 ↔ 내 게시물 보기 버튼 토글 UI 및 기능 연동

### [modify] 이용권상태, 매니저 페이지 & ErpMain.jsx페이지
- SubscriptionState
- fetchSubscriptionData 함수로 데이터 요청 로직 정리
- 영수증 API 호출 시 404 응답 별도 처리하여 사용자 혼동 방지
- useEffect 내부 코드 간소화 및 구조 개선

### ErpMain
ERP 메인에 알림 목록(NotificationList) 페이지 추가 및 쿼리 파라미터 기반 뷰모드 지원
- '알림 목록' 메뉴 클릭 시 NotificationList 컴포넌트 렌더링
- URL 쿼리 파라미터(view, id)로 초기 뷰 설정 가능하도록 useLocation 로직 추가
- 공지사항 상세 진입 시 viewMode 및 id 값 URL로 반영 가능

### ErpNotiDetail.jsx
공지사항 상세 페이지에서 본인 게시글에만 수정 버튼 노출되도록 조건 추가
- localStorage에서 로그인 사번(empId) 조회
- 작성자와 현재 사용자 ID 비교 후 수정 버튼 조건부 렌더링

### SubscriptionManager
구독 관리 테이블에 닉네임 컬럼 추가 및 회원 식별성 강화
- 구독 회원 목록에 닉네임(nickname) 열 추가
- 중복된 이름이 있을 경우 식별 용이성 향상


### [modify] Purchase 컨트롤러, 서비스, 레포, 엔티티

### PurchaseService.java
- getSubscriptionPage() 메서드에서 JPQL 기반 PurchaseRepo.findActiveWithUser() 호출 제거
- 대신 UserListRepository.findByNameContainingIgnoreCase()로 사용자 목록 페이징 조회 후, 개별 사용자에 대한 Purchase 조회 방식으로 변경
- Optional.map().orElse(null) 패턴으로 Purchase가 없는 사용자 예외 처리
- PageImpl 생성 시 userPage.getTotalElements() → dtoList.size()로 정확한 응답 크기 반영

### PurchaeController.java
- refundPayment() 메서드에서 기존의 ResponseEntity.ok(refunded) → ResponseEntity.ok().build()로 환불 응답 본문 제거

### purchase.java
- Purchase → User 간 https://github.com/manytoone(fetch = FetchType.LAZY) 연관관계 필드 추가 (user)
- user_uuid 외래키를 https://github.com/joincolumn(name = "user_uuid", insertable = false, updatable = false)로 지정하여 DB 제어는 하지 않고, 조회용으로만 사용
- @JsonIgnore 설정으로 직렬화 방지
- 관리자 페이지 등에서 유저 정보(name, nickname 등)와 함께 구독 정보를 조회할 수 있게 개선됨

### PurchaseLogRepo.java
- findActiveWithUser(String keyword, Pageable pageable) 메서드 추가
- JPQL에서 JOIN FETCH p.user를 통해 N+1 문제 방지
- 유저 이름 및 닉네임에 키워드를 포함한 결과 필터링 가능
- 관리자용 이용권 검색 및 페이지네이션 UI에 활용됨

### [modify] ErpNoti 컨트롤러, 서비스, 레포
- ErpNotiController.java
-GET /api/notices/search 요청에 empId 파라미터 추가로 본인 작성 글 필터링 가능
-ErpNotiController.searchNotices() 메서드 시그니처 수정: @RequestParam empId 추가
-서비스 계층 searchNoticesWithPaging() 호출 방식도 이에 맞춰 변경됨
-사용자의 "내 게시물만 보기" 기능 구현을 위한 확장

### ErpNotiRepository.java
-공지사항 검색 조건에 작성자(empId) 필터 및 내일 만료 공지 조회 기능 추가

### ErpNotiService.java
공지 등록 시 내일 만료되는 경우 자동 알림 생성 기능 추가
- 공지 등록 시 만료일이 내일이면 Notification 엔티티를 통해 "ALL" 직원 대상 알림 자동 생성
- 중복 알림 방지를 위해 empId + relatedId + relatedType 조합으로 사전 존재 여부 체크
- 관련 repo(NotificationRepo) 주입 및 createNotice() 로직 내 알림 생성 코드 삽입

### [modify] ErpSchedule 서비서, 레포

### ErpSchedule
- 일정 마감 하루 전 알림 자동 생성 기능 추가
- @scheduled 작업을 통해 매일 자정, 다음날 마감되는 일정 조회
- 일정 마감 알림(Notification) 자동 생성 로직 추가
- 중복 방지 위해 relatedType + relatedId + empId 조합으로 사전 체크
- ErpScheduleService에 NotificationRepo 및 EmpRepository 주입

### ErpScheduleRepo
- 내일 만료될 일정 메서드 추가

### [modify] TicoTeamApplication & EmpRepository & SubscriptionResponseDTO

### TicoTeamApplication.java
- 스케줄링 기능 활성화를 위한 @EnableScheduling 추가
- TicoTeamApplication에 @EnableScheduling 어노테이션 추가
- 매일 자정에 실행되는 공지/일정 만료 알림 자동화를 위한 설정

### EmpRepository
- EmpRepository에 empId 존재 여부 확인 메서드 추가
- existsByEmpId(String empId) 메서드 추가로 알림 생성 시 사원 존재 여부 체크 가능
- 사원 번호 유효성 검증 및 실수 방지 로직에 활용됨

### SubscriptionResponseDTO
- 회원 닉네임 추가(닉네임은 중복안됨)

### [feat] Notification 컨트롤러, 서비스, 레포, 엔티티

### NotificationController.java
- NotificationController 구현 - 알림 조회, 읽음 처리, 삭제 기능 추가
- 개인 및 공용 알림 전체/미읽음 조회, 읽음 처리, 개별/전체 삭제 API 구현
- 공용 알림 숨김 처리(dismiss) 기능 추가
- 사원 ID 기반으로 알림 대상자 구분

### NotificationService.java
알림 서비스(NotificationService) 구현 및 만료 알림 스케줄링 추가
- 개인/공용 알림 조회, 읽음 처리, 삭제 처리 로직 구현
- 공용 알림에 대한 숨김 처리 및 읽음 기록 저장 기능 추가
- 공지사항/일정의 만료일 기준으로 매일 자정 자동 알림 생성 스케줄링 로직 추가 (@scheduled)
- 관련 알림 DTO 및 dismiss/read 기록 엔티티 연동

### NotificationRepo.java
NotificationRepo에 개인/공용 알림 조회 및 중복 알림 체크 메서드 추가
- 사원별 전체 알림/읽지 않은 알림 정렬 조회 메서드 추가
- 중복 알림 방지를 위한 existsBy 관련 조건 쿼리 추가

### NotificationReadRepo.java
NotificationReadRepo에 알림 읽음 여부 확인 및 단건 조회 메서드 추가
- existsByNotificationIdAndEmpId: 특정 알림이 읽혔는지 여부 확인
- findByNotificationIdAndEmpId: 알림 읽음 기록 단건 조회

### NotificationDismissedRepo에.java
NotificationDismissedRepo에 공용 알림 숨김 여부 확인 기능 추가
- existsByNotificationIdAndEmpId: 사용자가 공용 알림을 숨겼는지 확인하는 메서드 구현
- NotificationDismissed 엔티티에 대한 JPA 리포지토리 정의

### NotificationReadId.java
NotificationReadId 복합키 식별자 클래스 생성
- 알림 읽음 처리 상태 저장을 위한 복합키 클래스(NotificationReadId) 추가
- Serializable 인터페이스 구현 및 equals/hashCode 오버라이딩을 위해 Lombok 어노테이션 사용

### NotificationDismissedId.java
공용 알림 숨김 처리용 복합키 ID 클래스(NotificationDismissedId) 추가
- NotificationDismissed 엔티티에 사용될 복합키 식별자 클래스 생성
- Serializable 인터페이스 구현 및 equals/hashCode 오버라이드
- 공용 알림에 대한 사용자별 숨김 처리 기능 기반 마련

### NotificationDismissed.java
NotificationDismissed에 2-파라미터 생성자 추가 및 Serializable 구현 보완
- 공용 알림 숨김 기록 저장을 위한 NotificationDismissed 엔티티에 생성자(Long, String) 추가
- dismissedAt 필드 자동 초기화
- 직렬화 지원을 위한 serialVersionUID 명시
- 기존 @AllArgsConstructor로는 사용 불가능했던 생성자 호출 유연성 확보

### NotificationRead.java
알림 읽음 상태 저장 엔티티(NotificationRead) 추가
- 복합키 기반 알림 읽음 처리용 엔티티 NotificationRead 생성
- @IdClass(NotificationReadId.class)를 통한 복합키 구성
- 읽은 시간(readAt) 자동 저장 기능 추가
- 알림 읽음 여부를 사용자별로 관리 가능

### Notification.java
Notification 엔티티에 사용자별 읽음 상태 필드 readByCurrentUser 추가
- @transient 필드 readByCurrentUser 추가: 공용 알림의 사용자별 읽음 여부 프론트에서 표시하기 위함
- 기존 DB 컬럼에 영향 없이 사용자 개인 상태 표시 가능
- 전체 알림 조회 시 해당 필드 세팅을 통해 프론트 UX 개선
<br>

## Key Changes 🔑
<!-- 어떤 변경사항이 있었는지?-->
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 추가(README.MD,,)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 커밋 수정 (reset/revert/rename..)
<br>

## To Reviewrs ✍🏻
-

